### PR TITLE
Fix fish-shell prompt not working.

### DIFF
--- a/src/subshell.c
+++ b/src/subshell.c
@@ -769,7 +769,7 @@ init_subshell (void)
 {
     /* This must be remembered across calls to init_subshell() */
     static char pty_name[BUF_SMALL];
-    char precmd[BUF_SMALL];
+    char precmd[BUF_SMALL*2];
 
     switch (check_sid ())
     {
@@ -899,10 +899,9 @@ init_subshell (void)
         break;
     case FISH:
         g_snprintf (precmd, sizeof (precmd),
-                    " function __mc_after_fish_prompt --on-event fish_prompt ; pwd>&%d;kill -STOP %%self; end\n",
+                    " functions -c fish_prompt __mc_saved_fish_prompt; function fish_prompt; while test -z (pwd); cd ..; end; __mc_saved_fish_prompt; pwd>&%d; kill -STOP %%self; end\n",
                     subshell_pipe[WRITE]);
         break;
-
     }
     write_all (mc_global.tty.subshell_pty, precmd, strlen (precmd));
 

--- a/src/subshell.c
+++ b/src/subshell.c
@@ -899,7 +899,7 @@ init_subshell (void)
         break;
     case FISH:
         g_snprintf (precmd, sizeof (precmd),
-                    "function fish_prompt ; pwd>&%d;kill -STOP %%self; end\n",
+                    " function __mc_after_fish_prompt --on-event fish_prompt ; pwd>&%d;kill -STOP %%self; end\n",
                     subshell_pipe[WRITE]);
         break;
 


### PR DESCRIPTION
On 2.0beta+, the fish_prompt function will get overwritten after
starting the shell. Instead, create a custom function that gets
triggered after the prompt is displayed.

As a bonus, this also makes the users own prompt appear both when
the panel is visible and hidden.

This will conflict with the fish_prompt changes in
https://www.midnight-commander.org/ticket/2742, but I don't think
that should be a big issue.
