### PR TITLE
Fix INFO file in deb archive

### DIFF
--- a/src/vfs/extfs/helpers/deb.in
+++ b/src/vfs/extfs/helpers/deb.in
@@ -34,7 +34,7 @@ sub mcdebfs_list
 	local($archivename)=@_;
 	local $qarchivename = quote($archivename);
 	chop($date=`LC_ALL=C date "+%b %d %H:%M"`);
-	chop($info_size=`LC_ALL=C dpkg -I $qarchivename | wc -c`);
+	chop($info_size=`dpkg -I $qarchivename | wc -c`);
 	$install_size=length($pressinstall);
 
 	print "dr-xr-xr-x   1 root     root     0 $date CONTENTS\n";


### PR DESCRIPTION
INFO file generate without LC_ALL e.g. in current locale. Size must be computed with same locale, otherwise content of INFO file will be chopped of for info_size

Example:
LC_ALL=ru_RU.utf8 dpkg -I ./test.deb |wc -c
772
LC_ALL=C dpkg -I ./test.deb |wc -c
680
