### PR TITLE
Unrar5 fixes

### DIFF
--- a/src/vfs/extfs/helpers/urar.in
+++ b/src/vfs/extfs/helpers/urar.in
@@ -51,7 +51,7 @@ flag==1 {
 	    $1="-rw-r--r--"
     printf "%s 1 %s %s %d %02d/%02d/%02d %s ./", $1, uid, gid, $2, a[2], a[1], a[3], $6
     for (i = 8; i < NF; ++i)
-	printf "%s ", $i
+        printf "%s ", $i
     printf "%s\n", $NF
 }'
 }

--- a/src/vfs/extfs/helpers/urar.in
+++ b/src/vfs/extfs/helpers/urar.in
@@ -49,7 +49,10 @@ flag==1 {
     else
 	if (index($1, ".") != 0)
 	    $1="-rw-r--r--"
-    printf "%s 1 %s %s %d %02d/%02d/%02d %s ./%s\n", $1, uid, gid, $2, a[2], a[1], a[3], $6, $8
+    printf "%s 1 %s %s %d %02d/%02d/%02d %s ./", $1, uid, gid, $2, a[2], a[1], a[3], $6
+    for (i = 8; i < NF; ++i)
+	printf "%s ", $i
+    printf "%s\n", $NF
 }'
 }
 


### PR DESCRIPTION
These commits fix displaying filenames with spaces while using unrar v5.
