### PR TITLE
Few important typo fixes

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -699,7 +699,7 @@ Version 4.7.5-pre1
     * Incorrect key event handling in "Listing mode" dialog (#2045)
     * Usability of field history in "Find file" dialog (#2046, #2407)
     * Find "Whole words" search bug (#2396)
-    * Directory ignorance doesn't work in file find (#2366, #2434)
+    * List of ignored directories doesn't work in file find (#2366, #2434)
     * Incorrect line jump when started as editor (#2344)
     * User menu in standalone mcedit doesn't show filetype-specific items (#1651)
     * Configure script doesn't set samba configdir (#2419)

--- a/doc/man/es/mc.1.in
+++ b/doc/man/es/mc.1.in
@@ -3937,7 +3937,7 @@ para volcar la selección de X Window a la salida estándar.
 Por ejemplo:
 .PP
 .nf
-clipboard_pastee=xclip \-o
+clipboard_paste=xclip \-o
 .fi
 .TP
 .I autodetect_codeset

--- a/doc/man/mc.1.in
+++ b/doc/man/mc.1.in
@@ -4103,7 +4103,7 @@ utility like 'xclip' to print the selection to standard out.
 For example:
 .PP
 .nf
-clipboard_pastee=xclip \-o
+clipboard_paste=xclip \-o
 .fi
 .TP
 .I autodetect_codeset


### PR DESCRIPTION
This fixes typos in setting names, or misused words, both pretty unfortunate kind of typos.
