### PR TITLE
Several improvements in editor saving behavior

### DIFF
--- a/src/editor/edit-impl.h
+++ b/src/editor/edit-impl.h
@@ -71,8 +71,6 @@
 
 #define get_sys_error(s) (s)
 
-#define edit_error_dialog(h,s) query_dialog (h, s, D_ERROR, 1, _("&Dismiss"))
-
 #define edit_query_dialog2(h,t,a,b) query_dialog (h, t, D_NORMAL, 2, a, b)
 #define edit_query_dialog3(h,t,a,b,c) query_dialog (h, t, D_NORMAL, 3, a, b, c)
 
@@ -281,6 +279,7 @@ gboolean is_break_char (char c);
 void edit_options_dialog (WDialog * h);
 void edit_syntax_dialog (WEdit * edit);
 void edit_mail_dialog (WEdit * edit);
+void edit_error_dialog (const char * h, const char * s);
 void format_paragraph (WEdit * edit, gboolean force);
 
 /* either command or char_for_insertion must be passed as -1 */

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -3252,6 +3252,23 @@ edit_mail_dialog (WEdit * edit)
 
 /* --------------------------------------------------------------------------------------------- */
 
+void
+edit_error_dialog (const char * h, const char * s)
+{
+    char *tmp;
+
+    if (!errno)
+        query_dialog (h, s, D_ERROR, 1, _("&Dismiss"));
+    else
+    {
+        tmp = g_strdup_printf (_("%s: %s"), s, unix_error_string (errno));
+        query_dialog (h, tmp, D_ERROR, 1, _("&Dismiss"));
+        g_free (tmp);
+    }
+}
+
+/* --------------------------------------------------------------------------------------------- */
+
 /*******************/
 /* Word Completion */
 /*******************/

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -321,9 +321,6 @@ edit_save_file (WEdit * edit, const vfs_path_t * filename_vpath)
         }
         if (mc_close (fd) != 0)
             goto error_save;
-        /* Update the file information, especially the mtime. */
-        if (mc_stat (savename_vpath, &edit->stat1) == -1)
-            goto error_save;
     }
     else
     {                           /* change line breaks */
@@ -379,6 +376,10 @@ edit_save_file (WEdit * edit, const vfs_path_t * filename_vpath)
     if (this_save_mode != EDIT_QUICK_SAVE)
         if (mc_rename (savename_vpath, real_filename_vpath) == -1)
             goto error_save;
+
+    /* Update the file information, especially the mtime. */
+    if (mc_stat (real_filename_vpath, &edit->stat1) == -1)
+        goto error_save;
 
     vfs_path_free (real_filename_vpath);
     vfs_path_free (savename_vpath);


### PR DESCRIPTION
By far the most frustrating thing in Midnight Commander for me was when I accidentally start editing a file in `/etc` while running mc as non-root, and then end up in a situation where I either have to discard my changes, re-run mc as root, and redo them, or save the file to my home directory and then manually `sudo cp` it over the destination. This patch solves the problem along with some others:
- OS errors are propagated to the user - editor errors now display `errno` (text and number), like the file manager
- Some spurious "The file has been modified in the meantime" messages were fixed
- When failing to save the current file, show an error message instead of displaying the "Save as..." dialog
- When failing to save a file (and displaying the reason why), allow the user to select "Save as..." or "Cancel"
- Additionally, if the user is not root, and the file failed to save due to an access or permission error, give the user the option "sudo", which will save the file to `mc_tmpdir` and run `sudo cp <tmpname> <target>` in the subshell. This allows the user to authenticate themselves to `sudo` and complete the file save.

If there are any issues with the patch, I'll be happy to address them and rebase the pull request.
