### PR TITLE
Recognize "Java archive data (JAR)" as zip archive.

### DIFF
--- a/misc/mc.ext.in
+++ b/misc/mc.ext.in
@@ -691,7 +691,7 @@ type/i/^zip\ archive
 	View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
 
 # jar(zip)
-type/i/^Java\ Jar\ file\ data\ \(zip\)
+type/i/^Java\ (Jar\ file|archive)\ data\ \((zip|JAR)\)
 	Open=%cd %p/uzip://
 	View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
 


### PR DESCRIPTION
This might not be enough to open jar files in mc again, as file has a bug as well: http://bugs.gw.com/view.php?id=360
