### PR TITLE
Fix vertical line color if a file is marked and selected

### DIFF
--- a/src/filemanager/panel.c
+++ b/src/filemanager/panel.c
@@ -860,8 +860,10 @@ format_file (WPanel * panel, int file_index, int width, int attr, gboolean issta
         }
         else
         {
-            if (attr == SELECTED || attr == MARKED_SELECTED)
+            if (attr == SELECTED)
                 tty_setcolor (SELECTED_COLOR);
+            else if (attr == MARKED_SELECTED)
+                tty_setcolor (MARKED_SELECTED_COLOR);
             else
                 tty_setcolor (NORMAL_COLOR);
             tty_print_one_vline (TRUE);


### PR DESCRIPTION
I'm creating my own theme for mc and I noticed that the vertical lines (`│`) of marked and selected files they had the `selected` color instead of `markselect`.
