### PR TITLE
update PKGBUILD.syntax according to latest pacman version

### DIFF
--- a/misc/syntax/PKGBUILD.syntax
+++ b/misc/syntax/PKGBUILD.syntax
@@ -5,20 +5,20 @@ context default
     keyword whole linestart pkgname brightcyan
     keyword whole linestart pkgver brightcyan
     keyword whole linestart pkgrel brightcyan
-    keyword whole linestart \[\s\]*pkgdesc brightcyan
+    keyword whole linestart pkgdesc brightcyan
     keyword whole linestart arch brightcyan
     keyword whole linestart url brightcyan
     keyword whole linestart license brightcyan
-    keyword whole linestart \[\s\]*groups brightcyan
-    keyword whole linestart \[\s\]*depends brightcyan
-    keyword whole linestart \[\s\]*makedepends brightcyan
-    keyword whole linestart \[\s\]*optdepends brightcyan
-    keyword whole linestart \[\s\]*provides brightcyan
-    keyword whole linestart \[\s\]*conflicts brightcyan
-    keyword whole linestart \[\s\]*replaces brightcyan
+    keyword whole linestart groups brightcyan
+    keyword whole linestart depends brightcyan
+    keyword whole linestart makedepends brightcyan
+    keyword whole linestart optdepends brightcyan
+    keyword whole linestart provides brightcyan
+    keyword whole linestart conflicts brightcyan
+    keyword whole linestart replaces brightcyan
     keyword whole linestart backup brightcyan
     keyword whole linestart options brightcyan
-    keyword whole linestart \[\s\]*install brightcyan
+    keyword whole linestart install brightcyan
     keyword whole linestart source brightcyan
     keyword whole linestart noextract brightcyan
     keyword whole linestart backup brightcyan

--- a/misc/syntax/PKGBUILD.syntax
+++ b/misc/syntax/PKGBUILD.syntax
@@ -3,6 +3,7 @@
 context default
     keyword whole linestart pkgbase brightcyan
     keyword whole linestart pkgname brightcyan
+    keyword whole linestart epoch brightcyan
     keyword whole linestart pkgver brightcyan
     keyword whole linestart pkgrel brightcyan
     keyword whole linestart pkgdesc brightcyan
@@ -13,6 +14,7 @@ context default
     keyword whole linestart depends brightcyan
     keyword whole linestart makedepends brightcyan
     keyword whole linestart optdepends brightcyan
+    keyword whole linestart checkdepends brightcyan
     keyword whole linestart provides brightcyan
     keyword whole linestart conflicts brightcyan
     keyword whole linestart replaces brightcyan
@@ -22,6 +24,8 @@ context default
     keyword whole linestart source brightcyan
     keyword whole linestart noextract brightcyan
     keyword whole linestart backup brightcyan
+    keyword whole linestart changelog brightcyan
+    keyword whole linestart validpgpkeys brightcyan
     keyword whole linestart md5sums brightcyan
     keyword whole linestart sha1sums brightcyan
     keyword whole linestart sha256sums brightcyan
@@ -175,6 +179,7 @@ wholechars abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._
     keyword whole mktemp cyan
     keyword whole more cyan
     keyword whole mount cyan
+    keyword whole msg cyan
     keyword whole mt cyan
     keyword whole mv cyan
     keyword whole netconf cyan
@@ -423,8 +428,10 @@ context exclusive linestart options ) lightgray
     keyword whole zipman brightgreen
     keyword whole ccache brightgreen
     keyword whole distcc brightgreen
+    keyword whole buildflags brightgreen
     keyword whole makeflags brightgreen
-    keyword whole force brightgreen
+    keyword whole debug brightgreen
+    keyword whole upx brightgreen
 
     keyword whole !strip brightred
     keyword whole !docs brightred
@@ -433,8 +440,10 @@ context exclusive linestart options ) lightgray
     keyword whole !zipman brightred
     keyword whole !ccache brightred
     keyword whole !distcc brightred
+    keyword whole !buildflags brightred
     keyword whole !makeflags brightred
-    keyword whole !force brightred
+    keyword whole !debug brightred
+    keyword whole !upx brightred
 
 context exclusive linestart arch ) lightgray
     keyword whole any brightcyan


### PR DESCRIPTION
This commit adds msg. debug,validpgpkey,changelog,epoch and removes force keyword according to current PKGBUILD man. [\s]\* removed because of it causes a mess especially with install keyword.
