### PR TITLE
Use PATH environment variable for Filtered View

### DIFF
--- a/lib/utilunix.c
+++ b/lib/utilunix.c
@@ -528,8 +528,8 @@ mc_popen (const char *command, GError ** error)
         goto ret_err;
     }
 
-    if (!g_spawn_async_with_pipes (NULL, argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD, NULL, NULL,
-                                   &p->child_pid, NULL, &p->out.fd, &p->err.fd, error))
+    if (!g_spawn_async_with_pipes (NULL, argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_SEARCH_PATH,
+                                   NULL, NULL, &p->child_pid, NULL, &p->out.fd, &p->err.fd, error))
     {
         mc_replace_error (error, MC_PIPE_ERROR_CREATE_PIPE_STREAM, "%s",
                           _("Cannot create pipe streams"));


### PR DESCRIPTION
mc does not use the PATH environment variable to search for the executable when performing a Filtered View command.

The filtered view command is run with the mc_popen function in lib/utilunix.c. This function runs the process with the glib function g_spawn_async_with_pipes, which by default requires the full path of the executable.

This change adds the G_SPAWN_SEARCH_PATH flag to the g_spawn_async_with_pipes function call, which causes mc to use the PATH environment variable to search for the executable.
