### PR TITLE
Editor: Use marked block as input for M-u command. fix a hung

### DIFF
--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -3215,9 +3215,9 @@ edit_ext_cmd (WEdit * edit)
     char *exp, *tmp, *tmp_edit_temp_file;
     int e;
 
-    char *stdin_str = g_strdup("/dev/null");
+    char *stdin_str = g_strdup ("/dev/null");
     off_t start_mark, end_mark;
-    int  block_present_flag = 0;
+    int block_present_flag = 0;
 
     exp =
         input_dialog (_("Paste output of external command"),
@@ -3229,20 +3229,21 @@ edit_ext_cmd (WEdit * edit)
     if (!exp)
         return 1;
 
-    if (eval_marks (edit, &start_mark, &end_mark)) {
-	g_free(stdin_str);
-	stdin_str = mc_config_get_full_path (EDIT_BLOCK_FILE);
-	edit_save_block (edit, stdin_str, start_mark, end_mark);
-	block_present_flag = 1;
+    if (eval_marks (edit, &start_mark, &end_mark))
+    {
+        g_free (stdin_str);
+        stdin_str = mc_config_get_full_path (EDIT_BLOCK_FILE);
+        edit_save_block (edit, stdin_str, start_mark, end_mark);
+        block_present_flag = 1;
     }
 
     tmp_edit_temp_file = mc_config_get_full_path (EDIT_TEMP_FILE);
-    tmp = g_strconcat ( "< ", stdin_str, " ", exp, " > ", tmp_edit_temp_file, (char *) NULL);
+    tmp = g_strconcat ("< ", stdin_str, " ", exp, " > ", tmp_edit_temp_file, (char *) NULL);
     g_free (tmp_edit_temp_file);
     e = system (tmp);
     g_free (tmp);
     g_free (exp);
-    g_free(stdin_str);
+    g_free (stdin_str);
 
     if (e)
     {
@@ -3251,9 +3252,10 @@ edit_ext_cmd (WEdit * edit)
     }
 
     edit->force |= REDRAW_COMPLETELY;
-    if (block_present_flag) {
-	if (edit_block_delete_cmd (edit))
-	    return 1;
+    if (block_present_flag)
+    {
+        if (edit_block_delete_cmd (edit))
+            return 1;
     }
 
     {

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -3215,7 +3215,7 @@ edit_ext_cmd (WEdit * edit)
     char *exp, *tmp, *tmp_edit_temp_file;
     int e;
 
-    const char *stdin_str = "/dev/null";
+    char *stdin_str = "/dev/null";
     off_t start_mark, end_mark;
     int  block_present_flag = 0;
 

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -3215,7 +3215,7 @@ edit_ext_cmd (WEdit * edit)
     char *exp, *tmp, *tmp_edit_temp_file;
     int e;
 
-    char *stdin_str = (char *)"/dev/null";
+    char *stdin_str = g_strdup("/dev/null");
     off_t start_mark, end_mark;
     int  block_present_flag = 0;
 
@@ -3230,6 +3230,7 @@ edit_ext_cmd (WEdit * edit)
         return 1;
 
     if (eval_marks (edit, &start_mark, &end_mark)) {
+	g_free(stdin_str);
 	stdin_str = mc_config_get_full_path (EDIT_BLOCK_FILE);
 	edit_save_block (edit, stdin_str, start_mark, end_mark);
 	block_present_flag = 1;
@@ -3241,8 +3242,7 @@ edit_ext_cmd (WEdit * edit)
     e = system (tmp);
     g_free (tmp);
     g_free (exp);
-    if (block_present_flag)
-	g_free(stdin_str);
+    g_free(stdin_str);
 
     if (e)
     {

--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -3215,7 +3215,7 @@ edit_ext_cmd (WEdit * edit)
     char *exp, *tmp, *tmp_edit_temp_file;
     int e;
 
-    char *stdin_str = "/dev/null";
+    char *stdin_str = (char *)"/dev/null";
     off_t start_mark, end_mark;
     int  block_present_flag = 0;
 


### PR DESCRIPTION
```
This is made like a sort command.

Fixes a bug: edtor hangs when external command
expect input from a stdin. A sort command M-t is don't needed
with this implemenmtaation of M-u ...

PS: I was thinked that this patch was already applied
```
