### PR TITLE
Editor: Use marked block as input for M-u command. fix a hang

### DIFF
--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -3218,6 +3218,10 @@ edit_ext_cmd (WEdit * edit)
     char *exp, *tmp, *tmp_edit_temp_file;
     int e;
 
+    char *stdin_str = g_strdup ("/dev/null");
+    off_t start_mark, end_mark;
+    int block_present_flag = 0;
+
     exp =
         input_dialog (_("Paste output of external command"),
                       _("Enter shell command(s):"), MC_HISTORY_EDIT_PASTE_EXTCMD, NULL,
@@ -3228,12 +3232,21 @@ edit_ext_cmd (WEdit * edit)
     if (!exp)
         return 1;
 
+    if (eval_marks (edit, &start_mark, &end_mark))
+    {
+        g_free (stdin_str);
+        stdin_str = mc_config_get_full_path (EDIT_BLOCK_FILE);
+        edit_save_block (edit, stdin_str, start_mark, end_mark);
+        block_present_flag = 1;
+    }
+
     tmp_edit_temp_file = mc_config_get_full_path (EDIT_TEMP_FILE);
-    tmp = g_strconcat (exp, " > ", tmp_edit_temp_file, (char *) NULL);
+    tmp = g_strconcat ("< ", stdin_str, " ", exp, " > ", tmp_edit_temp_file, (char *) NULL);
     g_free (tmp_edit_temp_file);
     e = system (tmp);
     g_free (tmp);
     g_free (exp);
+    g_free (stdin_str);
 
     if (e)
     {
@@ -3242,6 +3255,11 @@ edit_ext_cmd (WEdit * edit)
     }
 
     edit->force |= REDRAW_COMPLETELY;
+    if (block_present_flag)
+    {
+        if (edit_block_delete_cmd (edit))
+            return 1;
+    }
 
     {
         vfs_path_t *tmp_vpath;


### PR DESCRIPTION
```
This is made like a sort command.

Fixes a bug: edtor hangs when external command
expect input from a stdin. A sort command M-t is don't needed
with this implemenmtaation of M-u ...
```
