### PR TITLE
use diff syntax highlighting for git commit messages when GIT_EDITOR=…

### DIFF
--- a/misc/syntax/Syntax.in
+++ b/misc/syntax/Syntax.in
@@ -31,7 +31,7 @@ include filehighlight.syntax
 file ..\*\\.(e)$ Eiffel\sSource\sFile
 include eiffel.syntax
 
-file ..\*\\.(diff|rej|patch)$ Diff\sOutput ^(diff|Index:)\s
+file ..\*\\.(diff|rej|patch)|COMMIT_EDITMSG$ Diff\sOutput ^(diff|Index:)\s
 include diff.syntax
 
 file ..\*\\.lsm$ LSM\sFile


### PR DESCRIPTION
…mcedit
