### PR TITLE
Fixed missing header file in 'make dist' output.

### DIFF
--- a/src/subshell/Makefile.am
+++ b/src/subshell/Makefile.am
@@ -3,6 +3,7 @@ noinst_LTLIBRARIES = libsubshell.la
 libsubshell_la_SOURCES = \
 	common.c \
 	internal.h \
-	proxyfunc.c
+	proxyfunc.c \
+	subshell.h
 
 AM_CPPFLAGS = -I$(top_srcdir) $(GLIB_CFLAGS) $(PCRE_CPPFLAGS)


### PR DESCRIPTION
Fixed compilation error when mc compiled from tarball which prepared by 'make dist'

  command.c:49:35: fatal error: src/subshell/subshell.h: No such file or directory
  compilation terminated.
  make[3]: **\* [command.lo] Error 1
  make[3]: Leaving directory `/tmp/test/mc-tmp/mc-4.8.15-146-gf69b08b/src/filemanager'
  make[2]: **\* [all-recursive] Error 1
  make[2]: Leaving directory `/tmp/test/mc-tmp/mc-4.8.15-146-gf69b08b/src'
  make[1]: **\* [all-recursive] Error 1
  make[1]: Leaving directory `/tmp/test/mc-tmp/mc-4.8.15-146-gf69b08b'
  make: **\* [all] Error 2
