### PR TITLE
Added missing keywords: _ assert strictfp

### DIFF
--- a/misc/syntax/java.syntax
+++ b/misc/syntax/java.syntax
@@ -2,9 +2,14 @@
 #
 # Authors:
 # lol_zimmerli%headbanger.ch@mail.headbanger.ch, 1999
+#
+# 2016-03-21  Konrad Twardowski
+# * Added missing keywords: _ assert strictfp
 
 context default
+    keyword whole _ yellow
     keyword whole abstract yellow
+    keyword whole assert yellow
     keyword whole boolean yellow
     keyword whole break yellow
     keyword whole byte yellow
@@ -58,6 +63,7 @@ context default
     keyword whole return yellow
     keyword whole short yellow
     keyword whole static yellow
+    keyword whole strictfp yellow
     keyword whole super yellow
     keyword whole switch yellow
     keyword whole synchronized yellow


### PR DESCRIPTION
This small patch adds `assert/strictfp` as defined in [JLS](https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.9) and `_` (underscore) that [will be reserved](https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.27.1) in future JDK (Java 9).
