### PR TITLE
filemanager/mountlist.c: add makedev() declaration

### DIFF
--- a/src/filemanager/mountlist.c
+++ b/src/filemanager/mountlist.c
@@ -186,6 +186,7 @@
 
 #include "lib/global.h"
 #include "lib/strutil.h"        /* str_verscmp() */
+#include "lib/unixcompat.h"     /* makedev */
 #include "mountlist.h"
 
 /*** global variables ****************************************************************************/


### PR DESCRIPTION
On glibc-2.23 link fails as

```
$ mc-9999/src/filemanager/mountlist.c:750: undefined reference to `makedev'
```

Reported-by: Thomas D.
Bug: https://bugs.gentoo.org/579858
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
