### PR TITLE
Replace S_IWRITE with S_IWUSR

### DIFF
--- a/src/editor/editcmd.c
+++ b/src/editor/editcmd.c
@@ -1750,7 +1750,7 @@ edit_save_as_cmd (WEdit * edit)
                  * Allow user to write into saved (under another name) file
                  * even if original file had r/o user permissions.
                  */
-                edit->stat1.st_mode |= S_IWRITE;
+                edit->stat1.st_mode |= S_IWUSR;
             }
 
             rv = edit_save_file (edit, exp_vpath);


### PR DESCRIPTION
`S_IWRITE` is an obsolute constant that is not present on at least Android and can be safely replaced with `S_IWUSR`.
