### PR TITLE
fish integration: Ignore mc's prompt in history

### DIFF
--- a/src/subshell/common.c
+++ b/src/subshell/common.c
@@ -881,7 +881,7 @@ init_subshell_precmd (char *precmd, size_t buff_size)
          * Find out how to fix this.
          */
         g_snprintf (precmd, buff_size,
-                    "if not functions -q fish_prompt_mc;"
+                    " if not functions -q fish_prompt_mc;"
                     "functions -c fish_prompt fish_prompt_mc; end;"
                     "function fish_prompt;"
                     "echo (whoami)@(hostname -s):(set_color $fish_color_cwd)(pwd)(set_color normal)\\$\\ ; "


### PR DESCRIPTION
Fish does something equivalent to bash's "HISTCONTROL=ignoreboth" by default,
so simply prefixing a command with a space will let it be ignored.