### PR TITLE
Fix html viewing for files named *.foo.htm

### DIFF
--- a/misc/mc.ext.in
+++ b/misc/mc.ext.in
@@ -568,7 +568,7 @@ type/^PDF
 	View=%view{ascii} @EXTHELPERSDIR@/doc.sh view pdf
 
 # html
-regex/i/\.html?$
+regex/i/\.html{0,1}$
 	Open=@EXTHELPERSDIR@/web.sh open html
 	View=%view{ascii} @EXTHELPERSDIR@/web.sh view html
 


### PR DESCRIPTION
If the files are named as *.foo.htm and MC is compiled with GLIB search, the regex doesn't work correctly.
Making this change fixes the problem.

Ticket is created: http://www.midnight-commander.org/ticket/3728