### PR TITLE
issue: mc trac commit links require username/password

### DIFF
--- a/build-glib2.sh
+++ b/build-glib2.sh
@@ -3,6 +3,7 @@
 # Download and build glib 2.x statically with all dependencies and then
 # compile GNU Midnight Commander against it.
 # Copyright (C) 2003 Pavel Roskin
+
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
hi, sorry for using this "backdoor" to open an issue :)

i just today discovered this issue http://midnight-commander.org/ticket/3697#comment:15 and wanted to check out the referenced commit links, to find out if my netbsd-curses support patch broke anything and how it has been fixed, whether it was reverted, etc, but they're all password protected.

also notifying @ThomasDickey whose netbsd-curses writeup/critics i discovered today:
you mention some issues there which i cannot reproduce - UTF8 support works well for me, i've never seen a compilation fail due to __unused but i would be glad to fix it! also i'm not aware (neither is wikipedia from where i derived my knowledge) of any other than the 3 curses impls i mentioned, but then you're in this "business" since 20+ years... and as for the numbers in the README: the 128 MB result from the CFLAGS given in appendix A. it's mostly the combination of -ffunction-sections -fdata-sections + -g3 which bloat static libs quite a bit, but it's very effective in creating small static linked binaries (which i'm mainly interested in). anyhow, those numbers were taken during the very first days of netbsd-curses-portable, so i should probably redo them with current when i find time.

