### PR TITLE
fix macOS 10.13 compilation

### DIFF
--- a/lib/vfs/vfs.h
+++ b/lib/vfs/vfs.h
@@ -10,7 +10,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
-#ifdef HAVE_UTIMENSAT
+#if defined (HAVE_UTIMENSAT) && !defined(__APPLE__)
 #include <sys/time.h>
 #elif defined (HAVE_UTIME_H)
 #include <utime.h>
@@ -99,7 +99,7 @@ typedef void (*fill_names_f) (const char *);
 
 typedef void *vfsid;
 
-#ifdef HAVE_UTIMENSAT
+#if defined (HAVE_UTIMENSAT) && !defined(__APPLE__)
 typedef struct timespec mc_timesbuf_t[2];
 #else
 typedef struct utimbuf mc_timesbuf_t;

--- a/src/filemanager/file.c
+++ b/src/filemanager/file.c
@@ -664,7 +664,7 @@ warn_same_file (const char *fmt, const char *a, const char *b)
 static void
 get_times (const struct stat *sb, mc_timesbuf_t * times)
 {
-#ifdef HAVE_UTIMENSAT
+#if defined (HAVE_UTIMENSAT) && !defined(__APPLE__)
     (*times)[0] = sb->st_atim;
     (*times)[1] = sb->st_mtim;
 #else

--- a/src/vfs/fish/fish.c
+++ b/src/vfs/fish/fish.c
@@ -1395,7 +1395,7 @@ fish_chown (const vfs_path_t * vpath, uid_t owner, gid_t group)
 static void
 fish_get_atime (mc_timesbuf_t * times, time_t * sec, long *nsec)
 {
-#ifdef HAVE_UTIMENSAT
+#if defined (HAVE_UTIMENSAT) && !defined(__APPLE__)
     *sec = (*times)[0].tv_sec;
     *nsec = (*times)[0].tv_nsec;
 #else
@@ -1409,7 +1409,7 @@ fish_get_atime (mc_timesbuf_t * times, time_t * sec, long *nsec)
 static void
 fish_get_mtime (mc_timesbuf_t * times, time_t * sec, long *nsec)
 {
-#ifdef HAVE_UTIMENSAT
+#if defined (HAVE_UTIMENSAT) && !defined(__APPLE__)
     *sec = (*times)[1].tv_sec;
     *nsec = (*times)[1].tv_nsec;
 #else


### PR DESCRIPTION
On macOS 10.13 (High Sierra), `HAVE_UTIMENSAT` is defined by `configure` because macOS 10.13 does indeed have `utimensat`.

However, that macro is also used in mc's code to determine whether to use the `st_atim` or `st_atime` field of `struct stat` (as well as others). And thus compilation fails on macOS 10.13, whose `struct stat` does not have a `st_atim` field.

The pull request checks the `__APPLE__` macro. Another approach could be to use another configure check for the fields of the `struct stat`, rather than rely on `HAVE_UTIMENSAT`.