### PR TITLE
Enable Java .class files to be viewed even if JAD is not in the PATH

### DIFF
--- a/misc/ext.d/misc.sh.in
+++ b/misc/ext.d/misc.sh.in
@@ -48,7 +48,8 @@ do_view_action() {
         ctorrent -x "${MC_EXT_FILENAME}" 2>/dev/null
         ;;
     javaclass)
-        jad -p "${MC_EXT_FILENAME}" 2>/dev/null
+        jad -p "${MC_EXT_FILENAME}" 2>/dev/null || \
+            (file -b "${MC_EXT_FILENAME}"; javap -private "${MC_EXT_FILENAME}" 2>/dev/null)
         ;;
     *)
         ;;


### PR DESCRIPTION
* `file -b` prints the class file version, which `javap` doesn't by
  default.
* `javap`'s stderr should be suppressed (it may print `_JAVA_OPTIONS` if
  this variable is set).
