### PR TITLE
Use MPV as a fallback for mplayer -identify

### DIFF
--- a/misc/ext.d/video.sh
+++ b/misc/ext.d/video.sh
@@ -13,8 +13,14 @@ do_view_action() {
 
     case "${filetype}" in
     *)
-        mplayer -identify -vo null -ao null -frames 0 "${MC_EXT_FILENAME}" 2>&1 | \
-            sed -n 's/^ID_//p'
+        if mplayer >/dev/null 2>&1; then
+            mplayer -identify -vo null -ao null -frames 0 "${MC_EXT_FILENAME}" 2>&1 | \
+                sed -n 's/^ID_//p'
+        elif which mpv_identify.sh >/dev/null 2>&1; then
+            mpv_identify.sh "${MC_EXT_FILENAME}"
+        else
+            echo "Please install either mplayer or mpv to get information for this file"
+        fi
         ;;
     esac
 }


### PR DESCRIPTION
mplayer is not currently actively developed and some people have long switched to MPV - use it as a fallback for "mplayer -identify" command.

Also, give the user a hint about mplayer/mpv in case none of them is installed.