### PR TITLE
Fixed issues with formatting in polish hint file

### DIFF
--- a/doc/hints/l10n/mc.hint.pl
+++ b/doc/hints/l10n/mc.hint.pl
@@ -4,19 +4,19 @@ Porada: C-x p skopiuje nazwę bieżącej ścieżki do wiersza poleceń.
 
 Porada: uzupełnianie: M-Tab (lub Esc+Tab). Dwukrotne naciśnięcie wywołuje listę.
 
-Porada: M-p i\ M-n udostępni historię poleceń.
+Porada: M-p i M-n udostępni historię poleceń.
 
-Porada: cytowanie znaku można uzyskać przez Ctrl-q i\ odpowiedni znak.
+Porada: cytowanie znaku można uzyskać przez Ctrl-q i odpowiedni znak.
 
-Porada: te komunikaty można wyłączyć w\ menu Opcje/Układ.
+Porada: te komunikaty można wyłączyć w menu Opcje/Układ.
 
 Porada: zaznaczanie katalogów: należy dodać ukośnik na końcu wzorca dopasowania.
 
-Porada: jeśli w\ terminalu nie ma klawiszy funkcyjnych, można użyć Esc+numer.
+Porada: jeśli w terminalu nie ma klawiszy funkcyjnych, można użyć Esc+numer.
 
 Porada: witryna programu GNU Midnight Commander: http://www.midnight-commander.org
 
-Porada: raporty błędów (w\ języku angielskim) proszę wysłać na mc-devel@gnome.org
+Porada: raporty błędów (w języku angielskim) proszę wysłać na mc-devel@gnome.org
 
 Porada: klawisz Tab zmienia bieżący panel.
 
@@ -26,21 +26,21 @@ Porada: warto zajrzeć także na stronę podręcznika.
 
 Hint: Do you want Lynx-style navigation? Set it in the Configuration dialog.
 
-Porada: makra % działają także w\ wierszu poleceń.
+Porada: makra % działają także w wierszu poleceń.
 
-Porada: M-! umożliwia wyświetlenie wyjścia wykonywanych programów w\ podglądzie.
+Porada: M-! umożliwia wyświetlenie wyjścia wykonywanych programów w podglądzie.
 
-Porada: format wyświetlania listy plików można dostosować (więcej w\ „man mc”).
+Porada: format wyświetlania listy plików można dostosować (więcej w „man mc”).
 
-Porada: %D/%T oznacza zaznaczone pliki w\ drugim panelu.
+Porada: %D/%T oznacza zaznaczone pliki w drugim panelu.
 
-Porada: dostęp do zwykłej powłoki można uzyskać przez C-o, a\ powrót tak samo.
+Porada: dostęp do zwykłej powłoki można uzyskać przez C-o, a powrót tak samo.
 
 Porada: ustawienie zmiennej CDPATH może zaoszczędzić pisania przy cd.
 
-Porada: wyświetlanie plików .* można wybrać w\ oknie konfiguracji.
+Porada: wyświetlanie plików .* można wybrać w oknie konfiguracji.
 
-Porada: wyświetlanie plików zapasowych *~ można ustawić w\ oknie konfiguracji.
+Porada: wyświetlanie plików zapasowych *~ można ustawić w oknie konfiguracji.
 
 Porada: uzupełnianie działa wszędzie. Wystarczy nacisnąć M-Tab.
 
@@ -50,7 +50,7 @@ Porada: wyszukanie plików: można pracować na znalezionych plikach przez Filtr
 
 Porada: złożone wyszukiwanie można wykonać za pomocą polecenia Filtr zewnętrzny.
 
-Porada: można zmienić katalog w\ połowie podawania polecenia za pomocą M-c.
+Porada: można zmienić katalog w połowie podawania polecenia za pomocą M-c.
 
 Uwaga: polecenia powłoki działają tylko na lokalnych systemach plików.
 
@@ -58,21 +58,21 @@ Porada: można przywrócić usunięty tekst za pomocą C-y.
 
 Porada: jeśli jakiś klawisz nie działa, należy zobaczyć Opcje/Określ klawisze.
 
-Porada: aby zobaczyć wyjście polecenia w\ podglądzie, należy użyć M-!.
+Porada: aby zobaczyć wyjście polecenia w podglądzie, należy użyć M-!.
 
-Porada: F13 (lub Shift-F3) wywołuje podgląd w\ trybie oryginalnym.
+Porada: F13 (lub Shift-F3) wywołuje podgląd w trybie oryginalnym.
 
 Porada: można określić edytor dla klawisza F4 za pomocą zmiennej powłoki EDITOR.
 
 Porada: można określić zewnętrzny podgląd za pomocą zmiennych VIEWER lub PAGER.
 
-Porada: można wyłączyć wszystkie żądania potwierdzenia w\ Opcje/Potwierdzenia.
+Porada: można wyłączyć wszystkie żądania potwierdzenia w Opcje/Potwierdzenia.
 
 Hint: Leap to frequently used directories in a single bound with C-.
 
-Porada: można połączyć się z\ anonimowym FTP wpisując „cd ftp://komputer.edu”.
+Porada: można połączyć się z anonimowym FTP wpisując „cd ftp://komputer.edu”.
 
-Porada: FTP jest wbudowane w\ mc, proszę zobaczyć menu Plik/Połączenie FTP.
+Porada: FTP jest wbudowane w mc, proszę zobaczyć menu Plik/Połączenie FTP.
 
 Porada: M-t szybko zmienia tryb wyświetlania.
 
@@ -80,8 +80,8 @@ Porada: można podać użytkownika dla ftps: „cd ftp://użytkownik@komputer.ed
 
 Porada: można przeglądać pakiety RPM naciskając na nich klawisz Enter.
 
-Porada: aby zaznaczyć katalogi w\ oknie zaznaczania, należy dodać ukośnik.
+Porada: aby zaznaczyć katalogi w oknie zaznaczania, należy dodać ukośnik.
 
-Porada: użycie wycinania i\ wklejania za pomocą myszy wymaga klawisza Shift.
+Porada: użycie wycinania i wklejania za pomocą myszy wymaga klawisza Shift.
 
 Hint: Key frequently visited ftp sites in the hotlist: type C-.


### PR DESCRIPTION
Spaces in `mc.hints.pl` file were escaped but MC doesn't support escaping them there.