### PR TITLE
Make modarcon16 skin consistent with whitespaces

### DIFF
--- a/misc/skins/modarcon16.ini
+++ b/misc/skins/modarcon16.ini
@@ -144,7 +144,7 @@
     _default_ = color7;color0
     editbold = color15;;bold
     editmarked = color11;color2;bold
-    editwhitespace = color12;color4
+    editwhitespace = color2;color0
     editlinestate = color2;color0
     bookmark = color0;color7
     bookmarkfound = color0;color7


### PR DESCRIPTION
`modarcon16` skin is lovely and comfortable, but it has annoying
feature: editor whitespaces (i.e. tabs and trailing spaces) are
not consistent with other parts of skin, they're bright on blue.

This fix makes them green on black background.

Thank you for thinking about contributing to Midnight Commander, but we **ARE NOT** using pull requests to manage incoming patches!

Instead, please check out our Trac instance to see if the issue has already been reported, or submit a new ticket:

https://midnight-commander.org/wiki/NewTicket

If you chose to submit the pull request instead, keep in mind that we are not checking on them regularly, so it might take ages before we even get to it, if at all.

Unfortunately, GitHub does not allow us to disable the pull requests feature for this repository, so we have to warn you this way...
