### PR TITLE
compile on Solaris11.4 with ncurses

### DIFF
--- a/m4.include/mc-with-screen-ncurses.m4
+++ b/m4.include/mc-with-screen-ncurses.m4
@@ -133,6 +133,7 @@ AC_DEFUN([mc_WITH_NCURSES], [
         if test x"$ncurses_h_found" = "x"; then
             AC_MSG_ERROR([Cannot find ncurses header file])
         fi
+        AC_CHECK_HEADERS([ncurses/term.h])
 
         screen_type=ncurses
         screen_msg="NCurses"


### PR DESCRIPTION
ncurses on Solaris11.4 provides ncurses/term.h and HAVE_NCURSES_TERM_H need to be defined to compile tty-ncurses successfully
