### PR TITLE
fix-mc-user-variable

### DIFF
--- a/contrib/mc-wrapper.csh.in
+++ b/contrib/mc-wrapper.csh.in
@@ -1,4 +1,4 @@
-set MC_USER="`id | sed 's/[^(]*(//;s/).*//'`"
+set MC_USER=$(whoami)
 
 if ($?TMPDIR) then
 	setenv MC_PWD_FILE $TMPDIR/mc-$MC_USER/mc.pwd.$$

--- a/contrib/mc-wrapper.sh.in
+++ b/contrib/mc-wrapper.sh.in
@@ -1,4 +1,4 @@
-MC_USER=`id | sed 's/[^(]*(//;s/).*//'`
+MC_USER=$(whoami)
 MC_PWD_FILE="${TMPDIR-/tmp}/mc-$MC_USER/mc.pwd.$$"
 @bindir@/mc -P "$MC_PWD_FILE" "$@"
 


### PR DESCRIPTION
If AD authorization is used, then the "id" command works for a very long time (since it unloads all groups in the domain), it seems to me that it is more correct to use the "whoami" command

Thank you for thinking about contributing to Midnight Commander, but we **ARE NOT** using pull requests to manage incoming patches!

Instead, please check out our Trac instance to see if the issue has already been reported, or submit a new ticket:

https://midnight-commander.org/wiki/NewTicket

If you chose to submit the pull request instead, keep in mind that we are not checking on them regularly, so it might take ages before we even get to it, if at all.

Unfortunately, GitHub does not allow us to disable the pull requests feature for this repository, so we have to warn you this way...
