### PR TITLE
Change ISO processing to p7zip

### DIFF
--- a/misc/mc.ext.in
+++ b/misc/mc.ext.in
@@ -292,8 +292,8 @@ shell/.deba
 
 # ISO9660
 shell/i/.iso
-	Open=%cd %p/iso9660://
-	View=%view{ascii} @EXTHELPERSDIR@/misc.sh view iso9660
+	Open=%cd %p/u7z://
+	View=%view{ascii} @EXTHELPERSDIR@/archive.sh view 7z
 
 
 regex/\.(diff|patch)$


### PR DESCRIPTION
Rationale:
1) Most new PCs don't contain CD/DVD drives which means distros don't include isoinfo or similar tools
2) p7zip is a lot more powerful for processing ISOs as it can extract boot record(s) and other info which isoinfo doesn't see/understand