### PR TITLE
extfs s3+: port to Python 3

### DIFF
--- a/src/vfs/extfs/helpers/s3+.in
+++ b/src/vfs/extfs/helpers/s3+.in
@@ -153,16 +153,16 @@ def threadmap(fun, iterable, maxthreads=16):
 	Propagates exception safely.
 	"""
 	from threading import Thread
-	import Queue
+	import queue
 
 	items = list(iterable)
 	nitems = len(items)
 	if nitems < 2:
-		return map(fun, items)
+		return list(map(fun, items))
 
 	# Create and fill input queue
-	input = Queue.Queue()
-	output = Queue.Queue()
+	input = queue.Queue()
+	output = queue.Queue()
 
 	for i,item in enumerate(items):
 		input.put( (i,item) )
@@ -181,7 +181,7 @@ def threadmap(fun, iterable, maxthreads=16):
 						output.put( (i,result) )
 					except:
 						output.put( (None,sys.exc_info()) )
-				except Queue.Empty:
+				except queue.Empty:
 					return
 
 	# Start threads
@@ -196,8 +196,8 @@ def threadmap(fun, iterable, maxthreads=16):
 		try:
 			i,res = output.get()
 			if i == None:
-				raise res[0],res[1],res[2]
-		except Queue.Empty:
+				raise res[0](res[1]).with_traceback(res[2])
+		except queue.Empty:
 			break
 		ret.append(res)
 
@@ -241,7 +241,7 @@ def get_bucket(name):
 		b = s3.get_bucket(name, validate=False)
 		b.get_location() # just to raise an exception on error
 		return b
-	except boto.exception.S3ResponseError, e:
+	except boto.exception.S3ResponseError as e:
 		# Seems this is the only proper way to switch to the bucket's region.
 		# Requesting of the default region for "?location" does not work unfortunately.
 		m = re.search(r'<Region>(.*?)</Region>', e.body)
@@ -340,7 +340,7 @@ if cmd == 'list':
 	expr = re.compile(r'^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d{3}Z$')
 	def convDate(awsdatetime):
 		m = expr.match(awsdatetime)
-		ye,mo,da,ho,mi,se = map(int,m.groups())
+		ye,mo,da,ho,mi,se = list(map(int,m.groups()))
 
 		dt = datetime.datetime(ye,mo,da,ho,mi,se, tzinfo=pytz.utc)
 		return dt.astimezone(tz).strftime('%m-%d-%Y %H:%M')

--- a/src/vfs/extfs/helpers/uc1541
+++ b/src/vfs/extfs/helpers/uc1541
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 UC1541 Virtual filesystem
 


### PR DESCRIPTION
Original source: https://src.fedoraproject.org/rpms/mc/blob/master/f/mc-python3.patch