### PR TITLE
urar.in: fix for unrar/rar 6 and future versions

### DIFF
--- a/src/vfs/extfs/helpers/urar.in
+++ b/src/vfs/extfs/helpers/urar.in
@@ -113,7 +113,7 @@ mcrar5fs_list ()
 
 mcrarfs_list ()
 {
-    [ x$UNRAR_VERSION = x5 ] && mcrar5fs_list "$@" || mcrar4fs_list "$@"
+    [ x$UNRAR_VERSION != x4 ] && mcrar5fs_list "$@" || mcrar4fs_list "$@"
 }
 
 mcrarfs_copyin ()


### PR DESCRIPTION
Now that RAR 6.0 has been released this code breaks and uses the RAR 4 handler for RAR 6 archives. Adjust the comparison to use the RAR 5 handler for all future releases by default now that rar/unrar 4.0 is getting out of use.

