### PR TITLE
Add support for fast select in listbox by key

### DIFF
--- a/lib/widget/listbox.c
+++ b/lib/widget/listbox.c
@@ -339,6 +339,8 @@ static cb_ret_t
 listbox_key (WListbox * l, int key)
 {
     long command;
+    char text[2] = {0};
+    int idx = 0;
 
     if (l->list == NULL)
         return MSG_NOT_HANDLED;
@@ -348,7 +350,13 @@ listbox_key (WListbox * l, int key)
     {
         listbox_select_entry (l, key - '0');
         return MSG_HANDLED;
+    } else if(key >= 'a' && key <= 'z') {
+        text[0] = key;
+        idx = listbox_search_first_text(l, text);
+        listbox_select_entry(l, idx);
+        return MSG_HANDLED;
     }
+
 
     command = widget_lookup_key (WIDGET (l), key);
     if (command == CK_IgnoreKey)
@@ -587,6 +595,32 @@ listbox_search_text (WListbox * l, const char *text)
             WLEntry *e = LENTRY (le->data);
 
             if (strcmp (e->text, text) == 0)
+                return i;
+        }
+    }
+
+    return (-1);
+}
+
+/**
+ * Finds item by its label.
+ */
+int
+listbox_search_first_text (WListbox * l, const char *text)
+{
+    size_t text_len = strlen(text);
+
+    if (!listbox_is_empty (l))
+    {
+        int i;
+        GList *le;
+
+        for (i = 0, le = g_queue_peek_head_link (l->list); le != NULL; i++, le = g_list_next (le))
+        {
+            WLEntry *e = LENTRY (le->data);
+
+            // limit compare size, to avoid check for full string
+            if (strncmp (e->text, text, text_len) == 0)
                 return i;
         }
     }

--- a/lib/widget/listbox.h
+++ b/lib/widget/listbox.h
@@ -62,6 +62,7 @@ extern const global_keymap_t *listbox_map;
 
 WListbox *listbox_new (int y, int x, int height, int width, gboolean deletable, lcback_fn callback);
 int listbox_search_text (WListbox * l, const char *text);
+int listbox_search_first_text (WListbox * l, const char *text);
 int listbox_search_data (WListbox * l, const void *data);
 void listbox_select_first (WListbox * l);
 void listbox_select_last (WListbox * l);


### PR DESCRIPTION
This patch add support to fast move to item in list.
When a-z key is pressed, then it search first character in list and move select to him.

It is extremely usable on chown dialog, where searching for proper name is hell.
Now you can just press first character of name and it moves here.

