### PR TITLE
Ticket #4190: Remove (test "$MC_PWD" != "$PWD")

### DIFF
--- a/contrib/mc-wrapper.sh.in
+++ b/contrib/mc-wrapper.sh.in
@@ -4,7 +4,7 @@ MC_PWD_FILE="${TMPDIR-/tmp}/mc-$MC_USER/mc.pwd.$$"
 
 if test -r "$MC_PWD_FILE"; then
 	MC_PWD="`cat "$MC_PWD_FILE"`"
-	if test -n "$MC_PWD" && test "$MC_PWD" != "$PWD" && test -d "$MC_PWD"; then
+	if test -n "$MC_PWD" && test -d "$MC_PWD"; then
 		cd "$MC_PWD"
 	fi
 	unset MC_PWD


### PR DESCRIPTION
If you start at a directory, then navigate to the parent one,
delete it, recreate it, enter back and then exit the "cd" is
needed to avoid

shell-init: error retrieving current directory ...

Tested with bash-5.0.17-2.fc33.x86_64

See https://midnight-commander.org/ticket/4190

Thank you for thinking about contributing to Midnight Commander, but we **ARE NOT** using pull requests to manage incoming patches!

Instead, please check out our Trac instance to see if the issue has already been reported, or submit a new ticket:

https://midnight-commander.org/wiki/NewTicket

If you chose to submit the pull request instead, keep in mind that we are not checking on them regularly, so it might take ages before we even get to it, if at all.

Unfortunately, GitHub does not allow us to disable the pull requests feature for this repository, so we have to warn you this way...
