### PR TITLE
Add AES-256/GCM encryption support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -330,6 +330,11 @@ AC_CHECK_LIB(seq, get_process_stats, [
 		  [Define if you have function `get_process_stats' and
 have to use that instead of gettimeofday])])
 
+AC_CHECK_LIB(crypto, EVP_aes_256_gcm, [
+	LIBS="$LIBS -lcrypto"
+	AC_DEFINE(HAVE_AES_256_GCM, 1,
+		[Define if you are able to include mcedit's AES-256/GCM support])])
+
 mc_GET_FS_INFO
 
 

--- a/lib/keybind.h
+++ b/lib/keybind.h
@@ -317,6 +317,8 @@ enum
     CK_ExternalCommand,
     CK_Date,
     CK_EditMail,
+    CK_Encrypt,
+    CK_Decrypt,
 
     /* viewer */
     CK_WrapMode = 600L,

--- a/lib/widget/quick.h
+++ b/lib/widget/quick.h
@@ -80,6 +80,27 @@
     }                                                                           \
 }
 
+#define QUICK_LABELED_PASSWORD_INPUT(label_, label_loc, res)                    \
+{                                                                               \
+    .widget_type = quick_input,                                                 \
+    .options = WOP_DEFAULT,                                                     \
+    .pos_flags = WPOS_KEEP_DEFAULT,                                             \
+    .id = NULL,                                                                 \
+    .u = {                                                                      \
+        .input = {                                                              \
+            .label_text = label_,                                               \
+            .label_location = label_loc,                                        \
+            .label = NULL,                                                      \
+            .text = NULL,                                                       \
+            .completion_flags = INPUT_COMPLETE_NONE,                            \
+            .is_passwd = TRUE,                                                  \
+            .strip_passwd = TRUE,                                               \
+            .histname = NULL,                                                   \
+            .result = res                                                       \
+        }                                                                       \
+    }                                                                           \
+}
+
 #define QUICK_LABEL(txt, id_)                                                   \
 {                                                                               \
     .widget_type = quick_label,                                                 \

--- a/po/be.po
+++ b/po/be.po
@@ -4669,11 +4669,9 @@ msgstr "Працягваць ад пачатку?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Немагчыма атрымаць лакальную копію /ftp://some.host/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Падчас пераносу налад карыстальніка адбылася памылка: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4685,7 +4683,6 @@ msgstr "Немагчыма атрымаць лакальную копію /ftp:/
 #~ "Па падрабязнасці завітайце сюды:\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -4635,11 +4635,9 @@ msgstr "Да се продължи ли от началото?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Не може да се изтегли локално копие на /ftp://some.host/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Грешка възникна при преместването на потребителските настройки: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4651,7 +4649,6 @@ msgstr "Не може да се изтегли локално копие на /f
 #~ "За повече информация, моля посетете\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -4688,12 +4688,10 @@ msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 "No s'ha pogut obtenir una còpia local de /ftp://algun.amfitrió/editam.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr ""
 #~ "Hi ha hagut un error mentre es migraven els ajustaments d'usuari: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4705,7 +4703,6 @@ msgstr ""
 #~ "Per obtenir més informació, si us plau, visiteu\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -4682,11 +4682,9 @@ msgstr "Pokračovat od začátku?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Nedaří získat místní kopii souboru /ftp://some.host/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Nastala chyba při stěhování uživatelských nastavení: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4698,7 +4696,6 @@ msgstr "Nedaří získat místní kopii souboru /ftp://some.host/editme.txt"
 #~ "Další informace naleznete na\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/da.po
+++ b/po/da.po
@@ -4666,11 +4666,9 @@ msgstr "Fortsæt fra begyndelsen?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kan ikke hente en lokal kopi af /ftp://en.vært/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Der opstod en fejl ved flytning af brugerindstillinger: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4683,7 +4681,6 @@ msgstr "Kan ikke hente en lokal kopi af /ftp://en.vært/editme.txt"
 #~ "latest.html\n"
 #~ "for mere information"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/de.po
+++ b/po/de.po
@@ -4686,13 +4686,11 @@ msgstr "Am Anfang fortsetzen?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kann lokale Kopie von /ftp://some.host/editme.txt nicht erstellen"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr ""
 #~ "Während der Migration der Benutzereinstellungen ist ein Fehler "
 #~ "aufgetreten: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4704,7 +4702,6 @@ msgstr "Kann lokale Kopie von /ftp://some.host/editme.txt nicht erstellen"
 #~ "Besuchen Sie für weitere Informationen\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/el.po
+++ b/po/el.po
@@ -4519,7 +4519,6 @@ msgstr "Συνέχεια από την αρχή;"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4531,7 +4530,6 @@ msgstr ""
 #~ "Για να λάβετε περισσότερες πληροφορίες, παρακαλούμε επισκεφτείτε το\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4403,11 +4403,9 @@ msgstr ""
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "An error occurred while migrating user settings: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4419,7 +4417,6 @@ msgstr ""
 #~ "To get more info, please visit\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -4664,11 +4664,9 @@ msgstr "Ĉu deiri de la komenco?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Ne eblas atingi lokan kopion de /ftp://some.host/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Eraro okazis dum migrigi uzanto-agordon: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4680,7 +4678,6 @@ msgstr "Ne eblas atingi lokan kopion de /ftp://some.host/editme.txt"
 #~ "Por akiri pliajn informojn, bonvolu viziti\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/es.po
+++ b/po/es.po
@@ -4671,11 +4671,9 @@ msgstr "¿Continuar desde el principio?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Imposible obtener una copia local de /ftp://ese.equipo/edítame.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Error en la migración de la configuración personal: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4687,7 +4685,6 @@ msgstr "Imposible obtener una copia local de /ftp://ese.equipo/edítame.txt"
 #~ "Para más detalles consulte\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/et.po
+++ b/po/et.po
@@ -4646,11 +4646,9 @@ msgstr "Kas jätkata algusest?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Kohaliku koopia hankimine failist /ftp://some.host/editme.txt nurjus"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Viga kasutaja seadete migreerimisel: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4662,7 +4660,6 @@ msgstr "Kohaliku koopia hankimine failist /ftp://some.host/editme.txt nurjus"
 #~ "Lisainfot leiad aadressilt\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/eu.po
+++ b/po/eu.po
@@ -4658,11 +4658,9 @@ msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 "Ezin eskuratu ondokoaren bertako kopia bat: /ftp://some.host/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Errore bat gertatu da erabiltzaile-ezarpenak migratzean: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4674,7 +4672,6 @@ msgstr ""
 #~ "Info gehiago nahi baduzu, mesedez bisitatu\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -4391,6 +4391,5 @@ msgstr ""
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "هنگام انتقال اطلاعات کاربر خطایی رخ داد: %s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4664,13 +4664,11 @@ msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 "Impossible de récupérer localement le fichier /ftp://some.host/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr ""
 #~ "Une erreur est survenue lors de la migration des paramètres utilisateur : "
 #~ "%s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4682,7 +4680,6 @@ msgstr ""
 #~ "Pour plus d'informations, veuillez visiter\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/gl.po
+++ b/po/gl.po
@@ -4658,11 +4658,9 @@ msgstr "Continuar desde o principio?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Non é posíbel obter unha copia local de /ftp://some.host/editme.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Produciuse un erro ao migrar a configuración do usuario: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4674,7 +4672,6 @@ msgstr "Non é posíbel obter unha copia local de /ftp://some.host/editme.txt"
 #~ "Para obter máis detalles consulte\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4629,11 +4629,9 @@ msgstr "Folytatás az elejéről?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Nem sikerült behozni /ftp://some.host/editme.txt helyi másolatát"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Hiba történt a felhasználói adatok migrálásakor: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4645,7 +4643,6 @@ msgstr "Nem sikerült behozni /ftp://some.host/editme.txt helyi másolatát"
 #~ "További információ:\\n\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/id.po
+++ b/po/id.po
@@ -4424,11 +4424,9 @@ msgstr ""
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr ""
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Terjadi kesalahan saat migrasi setting pengguna: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4440,7 +4438,6 @@ msgstr ""
 #~ "Untuk penjelasan lebih lanjutm silahkan kunjungi\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/po/it.po
+++ b/po/it.po
@@ -4683,11 +4683,9 @@ msgstr "Continuare dall'inizio?"
 msgid "Cannot fetch a local copy of /ftp://some.host/editme.txt"
 msgstr "Impossibile ricevere copia locale di /ftp://un.host/modificami.txt"
 
-#, c-format
 #~ msgid "An error occurred while migrating user settings: %s"
 #~ msgstr "Errore durante la migrazione delle impostazioni dell'utente: %s"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to Freedesktop recommended dirs.\n"
@@ -4699,7 +4697,6 @@ msgstr "Impossibile ricevere copia locale di /ftp://un.host/modificami.txt"
 #~ "Per avere ulteriori informazioni, consultare\n"
 #~ "http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html"
 
-#, c-format
 #~ msgid ""
 #~ "Your old settings were migrated from %s\n"
 #~ "to %s\n"

--- a/src/editor/Makefile.am
+++ b/src/editor/Makefile.am
@@ -20,7 +20,8 @@ libedit_la_SOURCES = \
 	editwidget.c editwidget.h \
 	etags.c etags.h \
 	format.c \
-	syntax.c
+	syntax.c \
+	aes_gcm.h aes_gcm.c
 
 if USE_ASPELL
 if HAVE_GMODULE

--- a/src/editor/aes_gcm.c
+++ b/src/editor/aes_gcm.c
@@ -1,0 +1,374 @@
+/*
+   Editor encryption API.
+
+   Copyright (C) 2021
+   Free Software Foundation, Inc.
+
+   Written by:
+   Rafael Santiago <voidbrainvoid@tutanota.com> 2021
+
+   This file is part of the Midnight Commander.
+
+   The Midnight Commander is free software: you can redistribute it
+   and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   The Midnight Commander is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** \file aes_gcm.h
+ *  \brief Header: editor encryption API
+ *  \author Rafael Santiago
+ *  \date 2021
+ */
+
+#include "aes_gcm.h"
+#include <unistd.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/buffer.h>
+#include <glib.h>
+
+#define AES_GCM_IV_SIZE 16
+
+#define PBKDF2_ROUNDS_NR 10000
+
+static void derive_user_password (const char *password,
+                                  int password_size,
+                                  const unsigned char *salt, int salt_size,
+                                  unsigned char *key, int key_size);
+
+static int get_random_block (unsigned char *block, size_t block_size);
+
+static char *base64_encode (const unsigned char *buffer, size_t buffer_size, size_t *output_size);
+
+static unsigned char *base64_decode (const char *buffer, size_t buffer_size, size_t *output_size);
+
+static int aes256_gcm_encrypt (const unsigned char *plaintext, int plaintext_size,
+                               const char *password, int password_size,
+                               unsigned char *ciphertext,
+                               int tag_size, const unsigned char *aad, int aad_size);
+
+static int aes256_gcm_decrypt (const unsigned char *ciphertext, int ciphertext_size,
+                               const char *password, int password_size,
+                               unsigned char *plaintext,
+                               int tag_size, const unsigned char *aad, int aad_size);
+
+
+char *mc_aes256_gcm_encrypt_and_encode (const unsigned char *plaintext, size_t plaintext_size,
+                                        const char *password, int password_size,
+                                        size_t *output_size)
+{
+    unsigned char *ciphertext = NULL;
+    int ciphertext_size = 0;
+    char *output = NULL;
+
+    if (plaintext == NULL || plaintext_size == 0 || password == NULL ||
+        password_size == 0 || output_size == NULL) {
+        return NULL;
+    }
+
+    ciphertext = (unsigned char *) g_malloc0 (plaintext_size * 2 + 1024);
+
+    ciphertext_size = aes256_gcm_encrypt (plaintext, plaintext_size,
+                                          password, password_size,
+                                          ciphertext, 12, (unsigned char *)"", 0);
+
+    if (ciphertext_size <= 0) {
+        *output_size = 0;
+        return NULL;
+    }
+
+    output = base64_encode (ciphertext, ciphertext_size, output_size);
+
+    g_free (ciphertext);
+
+    return output;
+}
+
+unsigned char *mc_aes256_gcm_decode_and_decrypt (const char *ciphertext, size_t ciphertext_size,
+                                                 const char *password, int password_size,
+                                                 size_t *output_size)
+{
+    unsigned char *raw_ciphertext = NULL;
+    size_t raw_ciphertext_size = 0;
+    unsigned char *output = NULL;
+    int temp_size;
+
+    if (ciphertext == NULL || ciphertext_size == 0 || password == NULL || password_size == 0 ||
+        output_size == NULL) {
+        return NULL;
+    }
+
+    *output_size = 0;
+
+    raw_ciphertext = base64_decode (ciphertext, ciphertext_size, &raw_ciphertext_size);
+
+    if (raw_ciphertext == NULL || raw_ciphertext_size == 0) {
+        return NULL;
+    }
+
+    output = (unsigned char *) g_malloc0 (ciphertext_size + 2 * 1024);
+    temp_size = aes256_gcm_decrypt (raw_ciphertext, raw_ciphertext_size,
+			            password, password_size, output, 12, (unsigned char *)"", 0);
+    if (temp_size <= 0) {
+        *output_size = 0;
+        g_free (output);
+        output = NULL;
+    } else {
+        *output_size = (size_t) temp_size;
+    }
+
+    temp_size = 0;
+
+    return output;
+}
+
+void mc_clear_sensitive_buffer (void *buf, size_t buf_size)
+{
+    unsigned char *bp = (unsigned char *)buf;
+    unsigned char *bp_end = bp + buf_size;
+
+    /* avoid using memset because it can be dropped during optimizations */
+    while (bp != bp_end) {
+        *bp = 0;
+        bp++;
+    }
+}
+
+static void derive_user_password (const char *password,
+                                  int password_size,
+                                  const unsigned char *salt, int salt_size,
+                                  unsigned char *key, int key_size)
+{
+    PKCS5_PBKDF2_HMAC_SHA1 (password, password_size, salt, salt_size,
+                            PBKDF2_ROUNDS_NR, key_size, key);
+}
+
+static int get_random_block (unsigned char *block, size_t block_size)
+{
+    int fd = open ("/dev/urandom", O_RDONLY);
+    int done = (fd != -1);
+    if (fd != -1) {
+        read (fd, block, block_size);
+        close (fd);
+    }
+    return done;
+}
+
+static char *base64_encode (const unsigned char *buffer, size_t buffer_size, size_t *output_size)
+{
+    BIO *bio;
+    BUF_MEM *bufmem = NULL;
+
+    bio = BIO_new(BIO_s_mem());
+    bio = BIO_push(BIO_new(BIO_f_base64()), bio);
+    
+    BIO_write(bio, buffer, buffer_size);
+    BIO_flush(bio);
+
+    BIO_get_mem_ptr(bio, &bufmem);
+
+    BIO_set_close(bio, BIO_NOCLOSE);
+    BIO_free_all(bio);
+
+    *output_size = (bufmem->data != NULL) ? strlen(bufmem->data) : 0;
+
+    return bufmem->data;
+}
+
+static unsigned char *base64_decode (const char *buffer, size_t buffer_size, size_t *output_size)
+{
+    unsigned char *output;
+    BIO *bio;
+
+    output = (unsigned char *) g_malloc0(buffer_size);
+
+    if (output == NULL) {
+        *output_size = 0;
+	free(output);
+	return NULL;
+    }
+
+    bio = BIO_new_mem_buf(buffer, -1);
+    bio = BIO_push(BIO_new(BIO_f_base64()), bio);
+
+    *output_size = BIO_read(bio, output, buffer_size);
+
+    BIO_free_all(bio);
+
+    return output;
+}
+
+static int aes256_gcm_encrypt (const unsigned char *plaintext, int plaintext_size,
+                               const char *password, int password_size,
+                               unsigned char *ciphertext,
+                               int tag_size, const unsigned char *aad, int aad_size)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    int size;
+    int ciphertext_size = -1;
+    unsigned char iv[AES_GCM_IV_SIZE] = { 0 };
+    unsigned char key[32] = { 0 };
+    unsigned char *kp = NULL, *kp_end = NULL;
+
+    if (!(ctx = EVP_CIPHER_CTX_new ())) {
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    if (EVP_EncryptInit_ex (ctx, EVP_aes_256_gcm (), NULL, NULL, NULL) != 1) {
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    if (!get_random_block (iv, AES_GCM_IV_SIZE)) {
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    if (EVP_CIPHER_CTX_ctrl (ctx, EVP_CTRL_GCM_SET_IVLEN, AES_GCM_IV_SIZE,
+                             NULL) != 1) {
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    derive_user_password (password, password_size, (unsigned char *)"", 0, key, sizeof(key));
+
+    if (EVP_EncryptInit_ex (ctx, NULL, NULL, key, iv) != 1) {
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    if (aad != NULL && aad_size > 0 &&
+        EVP_EncryptUpdate (ctx, NULL, &size, aad, aad_size) != 1) {
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    if (EVP_EncryptUpdate (ctx, &ciphertext[AES_GCM_IV_SIZE + tag_size], &size,
+                           plaintext, plaintext_size) != 1) {
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    ciphertext_size = size;
+
+    memcpy (ciphertext, iv, AES_GCM_IV_SIZE);
+
+    if (EVP_EncryptFinal_ex (ctx, ciphertext + size, &size) != 1) {
+        ciphertext_size = -1;
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+    ciphertext_size += size;
+
+    if (EVP_CIPHER_CTX_ctrl (ctx, EVP_CTRL_GCM_GET_TAG, tag_size,
+                             &ciphertext[AES_GCM_IV_SIZE]) != 1) {
+        ciphertext_size = -1;
+        goto aes256_gcm_encrypt_epilogue;
+    }
+
+aes256_gcm_encrypt_epilogue:
+
+    if (ctx != NULL) {
+        EVP_CIPHER_CTX_free (ctx);
+    }
+
+    /*
+     * A memset over an unreferenced variable after this memset, tends to be
+     * dropped by the optimizer. Here we need to ensure that no key material
+     * will leak. The following code seems clumsy but it will do the job.
+     */
+    kp = &key[0];
+    kp_end = kp + sizeof (key);
+    while (kp != kp_end) {
+        *kp = 0;
+        kp++;
+    }
+
+    return ciphertext_size +
+                ((ciphertext_size > -1) ? (AES_GCM_IV_SIZE + tag_size) : 0);
+}
+
+static int aes256_gcm_decrypt (const unsigned char *ciphertext, int ciphertext_size,
+                               const char *password, int password_size,
+                               unsigned char *plaintext,
+                               int tag_size, const unsigned char *aad, int aad_size)
+{
+    EVP_CIPHER_CTX *ctx = NULL;
+    int size;
+    int plaintext_size;
+    int ret = 0;
+    unsigned char key[32] = { 0 };
+    unsigned char *kp = NULL, *kp_end = NULL;
+
+    if (!(ctx = EVP_CIPHER_CTX_new ())) {
+        goto aes256_gcm_decrypt_epilogue;
+    }
+
+    if (EVP_DecryptInit_ex (ctx, EVP_aes_256_gcm(), NULL, NULL, NULL) == 0) {
+        goto aes256_gcm_decrypt_epilogue;
+    }
+
+    if (EVP_CIPHER_CTX_ctrl (ctx, EVP_CTRL_GCM_SET_IVLEN, AES_GCM_IV_SIZE,
+                             NULL) == 0) {
+        goto aes256_gcm_decrypt_epilogue;
+    }
+
+    derive_user_password (password, password_size, (unsigned char *)"", 0, key, sizeof(key));
+
+    if (EVP_DecryptInit_ex (ctx, NULL, NULL, key, ciphertext) == 0) {
+        goto aes256_gcm_decrypt_epilogue;
+    }
+
+    if (aad != NULL && aad_size > 0 &&
+        EVP_DecryptUpdate (ctx, NULL, &size, aad, aad_size) == 0) {
+        goto aes256_gcm_decrypt_epilogue;
+    }
+
+    if (EVP_DecryptUpdate (ctx,
+                           plaintext,
+                           &size,
+                           (unsigned char *)&ciphertext[AES_GCM_IV_SIZE + tag_size],
+                           ciphertext_size - AES_GCM_IV_SIZE - tag_size) == 0) {
+        goto aes256_gcm_decrypt_epilogue;
+    }
+
+    plaintext_size = size;
+
+    if (EVP_CIPHER_CTX_ctrl (ctx, EVP_CTRL_GCM_SET_TAG, tag_size,
+                             (unsigned char *)&ciphertext[AES_GCM_IV_SIZE]) == 0) {
+        goto aes256_gcm_decrypt_epilogue;
+    }
+
+    ret = EVP_DecryptFinal_ex (ctx, plaintext + size, &size);
+
+aes256_gcm_decrypt_epilogue:
+
+    if (ctx != NULL) {
+        EVP_CIPHER_CTX_free (ctx);
+    }
+
+    /*
+     * A memset over an unreferenced variable after this memset, tends to be
+     * dropped by the optimizer. Here we need to ensure that no key material
+     * will leak. The following code seems clumsy but it will do the job.
+     */
+    kp = &key[0];
+    kp_end = kp + sizeof (key);
+    while (kp != kp_end) {
+        *kp = 0;
+        kp++;
+    }
+
+    return ((ret > 0) ? (plaintext_size + size) : -1);
+}
+
+#undef AES_GCM_IV_SIZE
+
+#undef PBKDF2_ROUNDS_NR

--- a/src/editor/aes_gcm.h
+++ b/src/editor/aes_gcm.h
@@ -1,0 +1,21 @@
+/** \file aes_gcm.h
+ *  \brief Header: editor encryption API
+ *  \author Rafael Santiago
+ *  \date 2021
+ */
+#ifndef MC__EDIT_AES_GCM_H
+#define MC__EDIT_AES_GCM_H
+
+#include <stdlib.h>
+
+char *mc_aes256_gcm_encrypt_and_encode (const unsigned char *plaintext, size_t plaintext_size,
+                                        const char *password, int password_size,
+                                        size_t *output_size);
+
+unsigned char *mc_aes256_gcm_decode_and_decrypt (const char *ciphertext, size_t ciphertext_size,
+                                                 const char *password, int password_size,
+                                                 size_t *output_size);
+
+void mc_clear_sensitive_buffer (void *buf, size_t buf_size);
+
+#endif /* MC__EDIT_AES_GCM_H */

--- a/src/editor/edit-impl.h
+++ b/src/editor/edit-impl.h
@@ -278,6 +278,11 @@ void edit_syntax_dialog (WEdit * edit);
 void edit_mail_dialog (WEdit * edit);
 void format_paragraph (WEdit * edit, gboolean force);
 
+#ifdef HAVE_AES_256_GCM
+gboolean edit_encrypt_cmd (WEdit * edit);
+gboolean edit_decrypt_cmd (WEdit * edit);
+#endif /* HAVE_AES_256_GCM */
+
 /* either command or char_for_insertion must be passed as -1 */
 void edit_execute_cmd (WEdit * edit, long command, int char_for_insertion);
 

--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -613,6 +613,14 @@ get_prev_undo_action (WEdit * edit)
     return c;
 }
 
+#ifdef HAVE_AES_256_GCM
+void edit_clean_actions (WEdit * edit)
+{
+    while (edit_pop_undo_action (edit) != STACK_BOTTOM)
+        ;
+}
+#endif /* HAVE_AES_256_GCM */
+
 /* --------------------------------------------------------------------------------------------- */
 /** is called whenever a modification is made by one of the four routines below */
 

--- a/src/editor/edit.h
+++ b/src/editor/edit.h
@@ -74,5 +74,9 @@ off_t edit_get_cursor_offset (const WEdit * edit);
 long edit_get_curs_col (const WEdit * edit);
 const char *edit_get_syntax_type (const WEdit * edit);
 
+#ifdef HAVE_AES_256_GCM
+void edit_clean_actions (WEdit * edit);
+#endif /* HAVE_AES_256_GCM */
+
 /*** inline functions ****************************************************************************/
 #endif /* MC__EDIT_H */

--- a/src/editor/editcmd_dialogs.h
+++ b/src/editor/editcmd_dialogs.h
@@ -30,5 +30,10 @@ char *editcmd_dialog_completion_show (const WEdit * edit, GQueue * compl, int ma
 void editcmd_dialog_select_definition_show (WEdit * edit, char *match_expr, GPtrArray * def_hash);
 
 int editcmd_dialog_replace_prompt_show (WEdit *, char *, char *, int, int);
+
+#ifdef HAVE_AES_256_GCM
+gboolean editcmd_get_encryption_password_dialog (char *, size_t);
+gboolean editcmd_get_decryption_password_dialog (char *, size_t);
+#endif /* HAVE_AES_256_GCM */
 /*** inline functions ****************************************************************************/
 #endif /* MC__EDITCMD_DIALOGS_H */

--- a/src/editor/editmenu.c
+++ b/src/editor/editmenu.c
@@ -192,6 +192,11 @@ create_command_menu (void)
 #endif /* HAVE_ASPELL */
     entries = g_list_prepend (entries, menu_entry_create (_("&Mail..."), CK_EditMail));
 
+#ifdef HAVE_AES_256_GCM
+    entries = g_list_prepend (entries, menu_separator_create());
+    entries = g_list_prepend (entries, menu_entry_create (_("En&crypt..."), CK_Encrypt));
+    entries = g_list_prepend (entries, menu_entry_create (_("&Decrypt..."), CK_Decrypt));
+#endif /* HAVE_AES_256_GCM */
 
     return g_list_reverse (entries);
 }

--- a/src/editor/editwidget.c
+++ b/src/editor/editwidget.c
@@ -482,6 +482,14 @@ edit_dialog_command_execute (WDialog * h, long command)
     case CK_SaveSetup:
         save_setup_cmd ();
         break;
+#ifdef HAVE_AES_256_GCM
+    case CK_Encrypt:
+        edit_encrypt_cmd ((WEdit *) g->current->data);
+        break;
+    case CK_Decrypt:
+        edit_decrypt_cmd ((WEdit *) g->current->data);
+        break;
+#endif /* HAVE_AES_256_GCM */
     default:
         ret = MSG_NOT_HANDLED;
         break;

--- a/tests/src/editor/Makefile.am
+++ b/tests/src/editor/Makefile.am
@@ -26,10 +26,12 @@ endif
 EXTRA_DIST = mc.charsets test-data.txt.in
 
 TESTS = \
-	editcmd__edit_complete_word_cmd
+	editcmd__edit_complete_word_cmd \
+	aes_gcm
 
 check_PROGRAMS = $(TESTS)
 
 editcmd__edit_complete_word_cmd_SOURCES = \
-	editcmd__edit_complete_word_cmd.c
+	editcmd__edit_complete_word_cmd.c \
+	aes_gcm.c
 

--- a/tests/src/editor/aes_gcm.c
+++ b/tests/src/editor/aes_gcm.c
@@ -1,0 +1,112 @@
+/*
+   src/editor - tests for mc_aes256_gcm_encrypt_encode/mc_aes256_gcm_decode_and_decrypt functions
+
+   Copyright (C) 2021
+   Free Software Foundation, Inc.
+
+   Written by:
+   Rafael Santiago <voidbrainvoid@tutanota.com>, 2021
+
+   This file is part of the Midnight Commander.
+
+   The Midnight Commander is free software: you can redistribute it
+   and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation, either version 3 of the License,
+   or (at your option) any later version.
+
+   The Midnight Commander is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define TEST_SUITE_NAME "/src/editor"
+
+#include "tests/mctest.h"
+#include "src/editor/aes_gcm.h"
+#include <ctype.h>
+#include <string.h>
+
+START_TEST (test_aes_gcm)
+{
+    char *ciphertext = NULL;
+    size_t ciphertext_size = 0;
+    unsigned char *plaintext = (unsigned char *)"'Essa gravata e o relatorio de harmonia de coisas belas\n"
+                                                "E um jardim suspenso dependurado no pescoco\n"
+                                                "De um homem simpatico e feliz'\n";
+    size_t plaintext_size = strlen((char *)plaintext);
+    const char *password = "o homem da gravata florida";
+    size_t password_size = strlen(password);
+    unsigned char *decrypted_data = NULL;
+    size_t decrypted_data_size;
+    size_t i;
+
+    /* invalid parameters */
+    ciphertext = mc_aes256_gcm_encrypt_and_encode (NULL, plaintext_size, password, password_size, &ciphertext_size);
+    mctest_assert_ptr_eq (ciphertext, NULL);
+
+    ciphertext = mc_aes256_gcm_encrypt_and_encode (plaintext, 0, password, password_size, &ciphertext_size);
+    mctest_assert_ptr_eq (ciphertext, NULL);
+
+    ciphertext = mc_aes256_gcm_encrypt_and_encode (plaintext, plaintext_size, NULL, password_size, &ciphertext_size);
+    mctest_assert_ptr_eq (ciphertext, NULL);
+
+    ciphertext = mc_aes256_gcm_encrypt_and_encode (plaintext, plaintext_size, password, 0, &ciphertext_size);
+    mctest_assert_ptr_eq (ciphertext, NULL);
+
+    ciphertext = mc_aes256_gcm_encrypt_and_encode (plaintext, plaintext_size, password, password_size, NULL);
+    mctest_assert_ptr_eq (ciphertext, NULL);
+
+    /* valid parameters but invalid password during decryption */
+    ciphertext = mc_aes256_gcm_encrypt_and_encode (plaintext, plaintext_size, password, password_size, &ciphertext_size);
+    mctest_assert_ptr_ne (ciphertext, NULL);
+
+    decrypted_data = mc_aes256_gcm_decode_and_decrypt (ciphertext, ciphertext_size, "wr0ng", 5, &ciphertext_size);
+
+    mctest_assert_ptr_eq (decrypted_data, NULL);
+    g_free (ciphertext);
+
+    ciphertext = mc_aes256_gcm_encrypt_and_encode (plaintext, plaintext_size, password, password_size, &ciphertext_size);
+    mctest_assert_ptr_ne (ciphertext, NULL);
+
+    /* invalid parameters */
+    decrypted_data = mc_aes256_gcm_decode_and_decrypt (NULL, ciphertext_size, password, password_size, &decrypted_data_size);
+    mctest_assert_ptr_eq (decrypted_data, NULL);
+
+    decrypted_data = mc_aes256_gcm_decode_and_decrypt (ciphertext, 0, password, password_size, &decrypted_data_size);
+    mctest_assert_ptr_eq (decrypted_data, NULL);
+
+    decrypted_data = mc_aes256_gcm_decode_and_decrypt (ciphertext, ciphertext_size, NULL, password_size, &decrypted_data_size);
+    mctest_assert_ptr_eq (decrypted_data, NULL);
+
+    decrypted_data = mc_aes256_gcm_decode_and_decrypt (ciphertext, ciphertext_size, password, 0, &decrypted_data_size);
+    mctest_assert_ptr_eq (decrypted_data, NULL);
+
+    decrypted_data = mc_aes256_gcm_decode_and_decrypt (ciphertext, ciphertext_size, password, password_size, NULL);
+    mctest_assert_ptr_eq (decrypted_data, NULL);
+
+    /* valid parameters and valid decryption password */
+    decrypted_data = mc_aes256_gcm_decode_and_decrypt (ciphertext, ciphertext_size,
+                                                       password, password_size, &decrypted_data_size);
+    mctest_assert_ptr_ne (decrypted_data, NULL);
+    mctest_assert_int_eq (decrypted_data_size, plaintext_size);
+    mctest_assert_int_eq (memcmp(decrypted_data, plaintext, plaintext_size), 0);
+    mc_clear_sensitive_buffer(decrypted_data, decrypted_data_size);
+    for (i = 0; i < decrypted_data_size; i++) {
+        mctest_assert_int_eq(decrypted_data[i], 0);
+    }
+    g_free (ciphertext);
+    g_free (decrypted_data);
+}
+END_TEST
+
+int main (void)
+{
+    TCase *tc_core;
+    tc_core = tcase_create ("Core");
+    tcase_add_test (tc_core, test_aes_gcm);
+    return mctest_run_all(tc_core);
+}
+


### PR DESCRIPTION
Hi there!

This pull request includes AES-256/GCM support for ´´mcedit´´:

- This support is only included if the build environment has ´´libcrypto´´.
The ``C`` macro ´´HAVE_AES_256_GCM´´ indicates it into the code.

- The access for encryption/decryption conveniences are done through
``Command|Encrypt...`` or ``Command|Decrypt...``

- Once encrypted the stack action (for undo issues) is cleaned-up.

- Even after encrypting or decrypting the user must save this action.

- When encrypting we also encode it into ``Base64`` in order to avoid
extended chars issues on systems without support for displaying them.

- When decrypting we also decode it from ``Base64``, of course.

- ``GCM`` mode will avoid processing any corrupted data or wrong password.

- User passwords are internally derived with ``PBKDF2``.

I am a long date ``mcedit`` user and always missed this kind of feature.
I believe that it can be useful to other users. As instance, we can easily send an end-to-end encryption email by combining ``(Command|Encrypt... + Command|Mail... + Command|Decrypt...)``.

Best regards!