### PR TITLE
add support for MacOS Mach-O and .dylib files

### DIFF
--- a/misc/ext.d/misc.sh.in
+++ b/misc/ext.d/misc.sh.in
@@ -35,6 +35,9 @@ do_view_action() {
     elf)
         file "${MC_EXT_FILENAME}" && nm -C "${MC_EXT_FILENAME}"
         ;;
+    dylib)
+        file "${MC_EXT_FILENAME}" && nm -n "${MC_EXT_FILENAME}"
+        ;;
     dbf)
         dbview -b "${MC_EXT_FILENAME}"
         ;;

--- a/misc/mc.ext.in
+++ b/misc/mc.ext.in
@@ -431,10 +431,18 @@ regex/i/\.(s|asm)$
 regex/\.(so|so\.[0-9\.]*)$
 	View=%view{ascii} @EXTHELPERSDIR@/misc.sh view so
 
+# .dylib libraries
+regex/\.(dylib|dylib\.[0-9\.]*)$
+	View=%view{ascii} @EXTHELPERSDIR@/misc.sh view dylib
+
 # Object
 type/^ELF
 	#Open=%var{PAGER:more} %f
 	View=%view{ascii} @EXTHELPERSDIR@/misc.sh view elf
+
+type/^Mach-O
+	#Open=%var{PAGER:more} %f
+	View=%view{ascii} @EXTHELPERSDIR@/misc.sh view dylib
 
 
 ### Documentation ###


### PR DESCRIPTION
I find very useful the Viewer feature which allows to inspect symbols of ELF files, when opening them with F3. 

Unfortunately, under MacOS, similar functionality for inspecting Mach-O files is missing.

This Pull Request fills this gap. The screenshot below demonstrates, how it will look like. 
<img width="1267" alt="Screenshot 2021-06-07 at 23 25 56" src="https://user-images.githubusercontent.com/35846529/121255195-6a1a3f80-c8ab-11eb-8d38-54c6ac3afd7a.png">
 
