### PR TITLE
improve YAML multiline blocks syntax highliting

### DIFF
--- a/misc/syntax/yaml.syntax
+++ b/misc/syntax/yaml.syntax
@@ -36,5 +36,6 @@ context ' ' green
     spellcheck
     keyword {{*}} brightred
 
-context exclusive |\[123456789\+\-\s\t\]\n \n- brown
-context exclusive >\[123456789\+\-\s\t\]\n \n- brown
+# The last word below may be: "\n*:\{\s\n\}", but used strict version suitable for more cases
+context exclusive |\[123456789\+\-\s\t\]\n \n\[\s-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz\]:\{\s\n\} brown
+context exclusive >\[123456789\+\-\s\t\]\n \n\[\s-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz\]:\{\s\n\} brown

--- a/misc/syntax/yaml.syntax
+++ b/misc/syntax/yaml.syntax
@@ -37,5 +37,5 @@ context ' ' green
     keyword {{*}} brightred
 
 # The last word below may be: "\n*:\{\s\n\}", but used strict version suitable for more cases
-context exclusive |\[123456789\+\-\s\t\]\n \n\[\s-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz\]:\{\s\n\} brown
-context exclusive >\[123456789\+\-\s\t\]\n \n\[\s-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz\]:\{\s\n\} brown
+context exclusive |\[123456789\+\-\s\t\]\n \n\n\[\s-\]\[-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz\]:\{\s\n\} brown
+context exclusive >\[123456789\+\-\s\t\]\n \n\n\[\s-\]\[-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz\]:\{\s\n\} brown


### PR DESCRIPTION
Please merge my syntax highlighting improvements for YAML multi-line blocks.

It does not fix all the [#4059](https://midnight-commander.org/ticket/4059), but makes multi-line blocks look pretty in many cases.
