### PR TITLE
Recognize vsix files as zip files

### DIFF
--- a/misc/filehighlight.ini
+++ b/misc/filehighlight.ini
@@ -25,7 +25,7 @@
     regexp=(^#.*|.*~$)
 
 [archive]
-    extensions=7z;Z;ace;apk;arc;arj;ark;bz2;cab;cpio;deb;gz;lha;lz;lz4;lzh;lzma;rar;rpm;tar;tbz;tbz2;tgz;tlz;txz;tzst;xz;zip;zoo;zst
+    extensions=7z;Z;ace;apk;arc;arj;ark;bz2;cab;cpio;deb;gz;lha;lz;lz4;lzh;lzma;rar;rpm;tar;tbz;tbz2;tgz;tlz;txz;tzst;vsix;xz;zip;zoo;zst
 
 [doc]
     extensions=chm;css;ctl;diz;doc;docm;docx;dtd;fodg;fodp;fods;fodt;htm;html;json;letter;lsm;mail;man;markdown;md;me;msg;nroff;odg;odp;ods;odt;pdf;po;ppt;pptm;pptx;ps;rtf;sgml;shtml;tex;text;txt;xls;xlsm;xlsx;xml;xsd;xslt

--- a/misc/mc.ext.in
+++ b/misc/mc.ext.in
@@ -740,7 +740,7 @@ shell/i/.arc
 	Extract (with flags)=I=%{Enter any Arc flags:}; if test -n "$I"; then arc x $I %f; fi
 
 # zip
-shell/i/.zip
+shell/i/.(zip|vsix)
 	Open=%cd %p/uzip://
 	View=%view{ascii} @EXTHELPERSDIR@/archive.sh view zip
 


### PR DESCRIPTION
vsix files are vscode code plugins and they just zip archives, so it makes sense to recognize them as alternative zip file extension.

References:
 - https://docs.microsoft.com/en-us/visualstudio/extensibility/anatomy-of-a-vsix-package?view=vs-2022
 - https://en.wikipedia.org/wiki/Open_Packaging_Conventions


Thank you for thinking about contributing to Midnight Commander, but we **ARE NOT** using pull requests to manage incoming patches!

Instead, please check out our Trac instance to see if the issue has already been reported, or submit a new ticket:

https://midnight-commander.org/wiki/NewTicket

If you chose to submit the pull request instead, keep in mind that we are not checking on them regularly, so it might take ages before we even get to it, if at all.

Unfortunately, GitHub does not allow us to disable the pull requests feature for this repository, so we have to warn you this way...
