### PR TITLE
Parameter 'Erase at end' now shows in setup box

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -1917,6 +1917,9 @@ msgstr "Автоим&я каталога"
 msgid "&Preallocate space"
 msgstr "Предварительно в&ыделить место"
 
+msgid "&Erase at end of move"
+msgstr "&Удалять в конце переноса"
+
 msgid "Esc key mode"
 msgstr "Клавиша Esc"
 

--- a/src/filemanager/boxes.c
+++ b/src/filemanager/boxes.c
@@ -554,6 +554,7 @@ configure_box (void)
                     QUICK_CHECKBOX (N_("Mkdi&r autoname"), &auto_fill_mkdir_name, NULL),
                     QUICK_CHECKBOX (N_("&Preallocate space"), &mc_global.vfs.preallocate_space,
                                     NULL),
+                    QUICK_CHECKBOX (N_("&Erase at end of move"), &erase_at_end, NULL),
                 QUICK_STOP_GROUPBOX,
                 QUICK_START_GROUPBOX (N_("Esc key mode")),
                     QUICK_CHECKBOX (N_("S&ingle press"), &old_esc_mode, &configure_old_esc_mode_id),

--- a/src/filemanager/fileopctx.c
+++ b/src/filemanager/fileopctx.c
@@ -32,6 +32,7 @@
  */
 
 #include <config.h>
+#include <src/setup.h>
 
 #include <unistd.h>
 
@@ -80,7 +81,7 @@ file_op_context_new (FileOperation op)
     ctx->preserve = TRUE;
     ctx->preserve_uidgid = (geteuid () == 0);
     ctx->umask_kill = 0777777;
-    ctx->erase_at_end = TRUE;
+    ctx->erase_at_end = erase_at_end;
     ctx->skip_all = FALSE;
 
     return ctx;

--- a/src/setup.c
+++ b/src/setup.c
@@ -161,6 +161,9 @@ gboolean only_leading_plus_minus = TRUE;
 /* Automatically fills name with current selected item name on mkdir */
 gboolean auto_fill_mkdir_name = TRUE;
 
+/* Erase files and directories at the end of moving */
+gboolean erase_at_end = TRUE;
+
 /* If set and you don't have subshell support, then C-o will give you a shell */
 gboolean output_starts_shell = FALSE;
 
@@ -365,6 +368,7 @@ static const struct
     { "shadows", &mc_global.tty.shadows },
     { "mcview_remember_file_position", &mcview_remember_file_position },
     { "auto_fill_mkdir_name", &auto_fill_mkdir_name },
+    { "erase_at_end", &erase_at_end },
     { "copymove_persistent_attr", &copymove_persistent_attr },
     { NULL, NULL }
 };

--- a/src/setup.h
+++ b/src/setup.h
@@ -95,6 +95,7 @@ extern gboolean auto_save_setup;
 extern gboolean only_leading_plus_minus;
 extern int cd_symlinks;
 extern gboolean auto_fill_mkdir_name;
+extern gboolean erase_at_end;
 extern gboolean output_starts_shell;
 #ifdef USE_FILE_CMD
 extern gboolean use_file_to_check_type;


### PR DESCRIPTION
The behavior parameter "Erase at end" was only at source code file ./mc/src/filemanager/fileopctx.c like:
```
ctx->erase_at_end = TRUE;
```

I've made the setup parameter at menu (F9) "Setup-Configuration": "File operations" - "Erase at end of move"
because I need to delete files during of movement, but not at the end of it.

So, I hope you will accept my efforts.