### PR TITLE
scripts: replace "perl -w" with "use warnings"

### DIFF
--- a/src/man2hlp/man2hlp.in
+++ b/src/man2hlp/man2hlp.in
@@ -1,4 +1,4 @@
-#! @PERL_FOR_BUILD@ -w
+#! @PERL_FOR_BUILD@
 #
 #  Man page to help file converter
 #  Copyright (C) 1994, 1995, 1998, 2000, 2001, 2002, 2003, 2004, 2005,

--- a/src/vfs/extfs/helpers/a+.in
+++ b/src/vfs/extfs/helpers/a+.in
@@ -1,4 +1,4 @@
-#! @PERL@ -w
+#! @PERL@
 #
 # External filesystem for mc, using mtools
 # Written Ludek Brukner <lubr@barco.cz>, 1997
@@ -8,6 +8,8 @@
 # 
 
 # These mtools components must be in PATH for this to work
+
+use warnings;
 
 sub quote {
     $_ = shift(@_);

--- a/src/vfs/extfs/helpers/mailfs.in
+++ b/src/vfs/extfs/helpers/mailfs.in
@@ -1,6 +1,7 @@
-#! @PERL@ -w
+#! @PERL@
 
 use bytes;
+use warnings;
 
 # MC extfs for (possibly compressed) Berkeley style mailbox files
 # Peter Daum <gator@cs.tu-berlin.de> (Jan 1998, mc-4.1.24)

--- a/src/vfs/extfs/helpers/patchfs.in
+++ b/src/vfs/extfs/helpers/patchfs.in
@@ -1,4 +1,4 @@
-#! @PERL@ -w
+#! @PERL@
 #
 # Written by Adam Byrtek <alpha@debian.org>, 2002
 # Rewritten by David Sterba <dave@jikos.cz>, 2009
@@ -9,6 +9,7 @@
 
 use bytes;
 use strict;
+use warnings;
 use POSIX;
 use File::Temp 'tempfile';
 

--- a/src/vfs/extfs/helpers/ulib.in
+++ b/src/vfs/extfs/helpers/ulib.in
@@ -1,8 +1,10 @@
-#! @PERL@ -w
+#! @PERL@
 #
 # VFS to manage the gputils archives.
 # Written by Molnár Károly (proton7@freemail.hu) 2012
 #
+
+use warnings;
 
 my %month = ('jan' => '01', 'feb' => '02', 'mar' => '03',
              'apr' => '04', 'may' => '05', 'jun' => '06',

--- a/src/vfs/extfs/helpers/uzip.in
+++ b/src/vfs/extfs/helpers/uzip.in
@@ -1,4 +1,4 @@
-#! @PERL@ -w
+#! @PERL@
 #
 # zip file archive Virtual File System for Midnight Commander
 # Version 1.4.0 (2001-08-07).
@@ -9,6 +9,7 @@
 use POSIX;
 use File::Basename;
 use strict;
+use warnings;
 
 #
 # Configuration options


### PR DESCRIPTION
The shebang's max length is usually 128 as defined in
/usr/include/linux/binfmts.h:
  #define BINPRM_BUF_SIZE 128

To get around this, '/usr/bin/env perl' in place of @PERL@ can be used, but
'/usr/bin/env perl -w' doesn't work:

/usr/bin/env: perl -w: No such file or directory

So replace "perl -w" with "use warnings" to make it work.

The man2hlp.in already has "use warnings;", so just removing '-w' is OK.

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>

Thank you for thinking about contributing to Midnight Commander, but we **ARE NOT** using pull requests to manage incoming patches!

Instead, please check out our Trac instance to see if the issue has already been reported, or submit a new ticket:

https://midnight-commander.org/wiki/NewTicket

If you chose to submit the pull request instead, keep in mind that we are not checking on them regularly, so it might take ages before we even get to it, if at all.

Unfortunately, GitHub does not allow us to disable the pull requests feature for this repository, so we have to warn you this way...
