### PR TITLE
Workaround. Fix. #373

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -362,7 +362,7 @@ main (int argc, char *argv[])
 
 #ifdef ENABLE_SUBSHELL
     /* Disallow subshell when invoked as standalone viewer or editor from running mc */
-    if (mc_global.mc_run_mode != MC_RUN_FULL && mc_global.run_from_parent_mc)
+    if (mc_global.shell->type == SHELL_SH || (mc_global.mc_run_mode != MC_RUN_FULL && mc_global.run_from_parent_mc))
         mc_global.tty.use_subshell = FALSE;
 
     if (mc_global.tty.use_subshell)


### PR DESCRIPTION
Fix for the tickets:
https://midnight-commander.org/ticket/373
https://midnight-commander.org/ticket/3658

It should not prevent to start mc cause lack of a subshell. Want to start with subshell disabled instead. 