### PR TITLE
Makefile portability fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -13,7 +13,7 @@ rm -f INSTALL && ln -s doc/INSTALL
 
 # Generate po/POTFILES.in
 ${XGETTEXT:-xgettext} --keyword=_ --keyword=N_ --keyword=Q_ --output=- \
-	`find . -name '*.[ch]'` | sed -ne '/^#:/{s/#://;s/:[0-9]*/\
+	`find . -name '*.[ch]'` | ${SED-sed} -ne '/^#:/{s/#://;s/:[0-9]*/\
 /g;s/ //g;p;}' | \
 	grep -v '^$' | sort | uniq >po/POTFILES.in
 

--- a/configure.ac
+++ b/configure.ac
@@ -707,7 +707,7 @@ po/Makefile.in
 
 dnl https://stackoverflow.com/questions/30897170/ac-subst-does-not-expand-variable/30932102#30932102
 AC_CONFIG_FILES(
-[misc/syntax/Syntax], [sed -i -e "s%\${prefix}%$PREFIX%" misc/syntax/Syntax], [export PREFIX=$prefix]
+[misc/syntax/Syntax], [${SED-sed} -i -e "s%\${prefix}%$PREFIX%" misc/syntax/Syntax], [export PREFIX=$prefix]
 )
 
 AC_CONFIG_FILES([

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -19,14 +19,14 @@ EXTRA_DIST = \
 	$(noinst_DATA)
 
 mc.csh: $(top_builddir)/config.status $(srcdir)/mc.csh.in
-	sed "s%@""pkglibexecdir@%$(pkglibexecdir)%" $(srcdir)/mc.csh.in > mc.csh
+	$(SED) "s%@""pkglibexecdir@%$(pkglibexecdir)%" $(srcdir)/mc.csh.in > mc.csh
 
 mc.sh: $(top_builddir)/config.status $(srcdir)/mc.sh.in
-	sed "s%@""pkglibexecdir@%$(pkglibexecdir)%" $(srcdir)/mc.sh.in > mc.sh
+	$(SED) "s%@""pkglibexecdir@%$(pkglibexecdir)%" $(srcdir)/mc.sh.in > mc.sh
 
 mc-wrapper.csh: $(top_builddir)/config.status $(srcdir)/mc-wrapper.csh.in
-	sed "s%@""bindir@%$(bindir)%" $(srcdir)/mc-wrapper.csh.in > mc-wrapper.csh
+	$(SED) "s%@""bindir@%$(bindir)%" $(srcdir)/mc-wrapper.csh.in > mc-wrapper.csh
 
 mc-wrapper.sh: $(top_builddir)/config.status $(srcdir)/mc-wrapper.sh.in
-	sed "s%@""bindir@%$(bindir)%" $(srcdir)/mc-wrapper.sh.in > mc-wrapper.sh
+	$(SED) "s%@""bindir@%$(bindir)%" $(srcdir)/mc-wrapper.sh.in > mc-wrapper.sh
 

--- a/doc/man/date-of-man-include.am
+++ b/doc/man/date-of-man-include.am
@@ -13,12 +13,12 @@ MAN_DATE_CMD = \
 
 mc.1: $(srcdir)/mc.1.in
 	MAN_FILE=$<; MAN_DATE=$$($(MAN_DATE_CMD)); \
-	sed $(SED_PARAMETERS) $< > $@
+	$(SED) $(SED_PARAMETERS) $< > $@
 
 mcedit.1: $(srcdir)/mcedit.1.in
 	MAN_FILE=$<; MAN_DATE=$$($(MAN_DATE_CMD)); \
-	sed $(SED_PARAMETERS) $< > $@
+	$(SED) $(SED_PARAMETERS) $< > $@
 
 mcview.1: $(srcdir)/mcview.1.in
 	MAN_FILE=$<; MAN_DATE=$$($(MAN_DATE_CMD)); \
-	sed $(SED_PARAMETERS) $< > $@
+	$(SED) $(SED_PARAMETERS) $< > $@

--- a/doc/man/date-of-man-include.am
+++ b/doc/man/date-of-man-include.am
@@ -12,13 +12,13 @@ MAN_DATE_CMD = \
 	    print POSIX::strftime("$(DATE_FORMAT)", localtime($$fi[9]));' 2>/dev/null
 
 mc.1: $(srcdir)/mc.1.in
-	MAN_FILE=$<; MAN_DATE=$$($(MAN_DATE_CMD)); \
-	$(SED) $(SED_PARAMETERS) $< > $@
+	MAN_FILE='$(srcdir)/mc.1.in'; MAN_DATE=$$($(MAN_DATE_CMD)); \
+	$(SED) $(SED_PARAMETERS) '$(srcdir)/mc.1.in' > '$@'
 
 mcedit.1: $(srcdir)/mcedit.1.in
-	MAN_FILE=$<; MAN_DATE=$$($(MAN_DATE_CMD)); \
-	$(SED) $(SED_PARAMETERS) $< > $@
+	MAN_FILE='$(srcdir)/mcedit.1.in'; MAN_DATE=$$($(MAN_DATE_CMD)); \
+	$(SED) $(SED_PARAMETERS) '$(srcdir)/mcedit.1.in' > '$@'
 
 mcview.1: $(srcdir)/mcview.1.in
-	MAN_FILE=$<; MAN_DATE=$$($(MAN_DATE_CMD)); \
-	$(SED) $(SED_PARAMETERS) $< > $@
+	MAN_FILE='$(srcdir)/mcview.1.in'; MAN_DATE=$$($(MAN_DATE_CMD)); \
+	$(SED) $(SED_PARAMETERS) '$(srcdir)/mcview.1.in' > '$@'

--- a/m4.include/mc-glib.m4
+++ b/m4.include/mc-glib.m4
@@ -49,7 +49,7 @@ AC_DEFUN([mc_G_MODULE_SUPPORTED], [
             esac
 
             if test -n "$lib"; then
-                lib1=`echo $i | sed 's/^-l//'`
+                lib1=`echo $i | ${SED-sed} 's/^-l//'`
                 if test -f "$GLIB_LIBDIR/lib${lib1}.a"; then
                     add="$GLIB_LIBDIR/lib${lib1}.a"
                 else

--- a/m4.include/mc-version.m4
+++ b/m4.include/mc-version.m4
@@ -10,7 +10,7 @@ dnl @modified Andrew Borodin <aborodin@vmail.ru>
 
 AC_DEFUN([mc_VERSION],[
     if test -f ${srcdir}/mc-version.h; then
-        VERSION=$(grep '^#define MC_CURRENT_VERSION' ${srcdir}/mc-version.h | sed 's/.*"\(.*\)"$/\1/')
+        VERSION=$(grep '^#define MC_CURRENT_VERSION' ${srcdir}/mc-version.h | ${SED-sed} 's/.*"\(.*\)"$/\1/')
     else
         VERSION="unknown"
     fi

--- a/maint/utils/find-dup-includes/runme.sh
+++ b/maint/utils/find-dup-includes/runme.sh
@@ -37,7 +37,7 @@ findIncludeDupsInDir() {
     dir_name=$1; shift
 
     for i in $(find "${dir_name}" -name '*.[ch]'); do
-        file_name=$(echo $i | sed 's@'"${MC_SOURCE_ROOT_DIR}/"'@@g')
+        file_name=$(echo $i | ${SED-sed} 's@'"${MC_SOURCE_ROOT_DIR}/"'@@g')
         [ $(grep "^\s*${file_name}$" -c "${MC_SOURCE_ROOT_DIR}/maint/utils/find-dup-includes/exclude-list.cfg") -ne 0 ] && continue
         "${MC_SOURCE_ROOT_DIR}/maint/utils/find-dup-includes/find-in-one-file.pl" "${i}"
     done

--- a/maint/utils/update-years.sh
+++ b/maint/utils/update-years.sh
@@ -9,7 +9,7 @@ LINE="Copyright (C)"
 for i in "$SOURCES"; do
     # replace year: XXXX-YYYY -> XXXX-ZZZZ
     # add year: XXXX -> XXXX-ZZZZ
-    sed -i -e "
+    ${SED-sed} -i -e "
         1,20 {
                 /$LINE/s/-[0-9]\{4\}$/-$YEAR/
         };
@@ -19,4 +19,4 @@ for i in "$SOURCES"; do
 done
 
 # special case
-sed -i -e "/$LINE/s/-[0-9]\{4\} the/-$YEAR the/" src/editor/editwidget.c
+${SED-sed} -i -e "/$LINE/s/-[0-9]\{4\} the/-$YEAR the/" src/editor/editwidget.c

--- a/po/Rules-pot-defaults
+++ b/po/Rules-pot-defaults
@@ -1,7 +1,7 @@
 
 update-po: Makefile
 	$(MAKE) $(DOMAIN).pot-update && \
-	sed \
+	$(SED) \
 	    -e '/#, fuzzy/d' \
 	    -e 's/Project-Id-Version: PACKAGE VERSION/Project-Id-Version: $(PACKAGE) $(VERSION)/' \
 	    -e 's/^"Plural-Forms: nplurals=INTEGER;/# "Plural-Forms: nplurals=INTEGER;/' \

--- a/tests/src/vfs/extfs/helpers-list/Makefile.am
+++ b/tests/src/vfs/extfs/helpers-list/Makefile.am
@@ -125,7 +125,7 @@ doc: README.html
 
 # (Thanks to VPATH we don't need to write "$(srcdir)/README". doc/hlp/Makefile.am needlessly does this.)
 README.html: README
-	pandoc --include-in-header=$(srcdir)/README.css.inc -N --old-dashes --toc --toc-depth=4 --standalone -o $@ $<
+	pandoc --include-in-header=$(srcdir)/README.css.inc -N --old-dashes --toc --toc-depth=4 --standalone -o '$@' '$(srcdir)/README'
 
 EXTRA_DIST += README.css.inc
 CLEANFILES += README.html

--- a/version.sh
+++ b/version.sh
@@ -63,7 +63,7 @@ SHOR_MC_VERSION="${PREV_MC_VERSION}"
 
 if [ -r "${VERSION_FILE}" ]
   then
-    PREV_MC_VERSION=`sed -n 's/^#define MC_CURRENT_VERSION "\(.*\)"$/\1/p' "${VERSION_FILE}"`
+    PREV_MC_VERSION=`${SED-sed} -n 's/^#define MC_CURRENT_VERSION "\(.*\)"$/\1/p' "${VERSION_FILE}"`
     CURR_MC_VERSION="${PREV_MC_VERSION}"
     SHOR_MC_VERSION="${PREV_MC_VERSION}"
 fi


### PR DESCRIPTION
This PR is designed to be used on top of PR #184.

The current POSIX specification for `make` can be checked at https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html. Look for `$<`

Potentially `$?` could be used instead of `$<` but `$?` is designed for different proposes and potentially could lead to other portability problems. As workarounds are simple and straightforward, I suggest to use them as in this PR.