### PR TITLE
configure: fix build with ncurses

### DIFF
--- a/m4.include/mc-with-screen-ncurses.m4
+++ b/m4.include/mc-with-screen-ncurses.m4
@@ -134,6 +134,8 @@ AC_DEFUN([mc_WITH_NCURSES], [
             AC_MSG_ERROR([Cannot find ncurses header file])
         fi
 
+        AC_CHECK_HEADERS([ncurses/term.h])
+
         screen_type=ncurses
         screen_msg="NCurses"
         AC_DEFINE(USE_NCURSES, 1, 


### PR DESCRIPTION
If ncurses location is not specified by configure parameters like '--with-ncurses-includes=/some/dir' then automatic detection at compiler default location is used. With automatic detection the header 'ncurses/term.h' is not checked therefore macro HAVE_NCURSES_TERM_H is not defined.