### PR TITLE
configure: fix duplication of ncurses in MCLIBS

### DIFF
--- a/m4.include/mc-with-screen-ncurses.m4
+++ b/m4.include/mc-with-screen-ncurses.m4
@@ -98,32 +98,33 @@ AC_DEFUN([mc_WITH_NCURSES], [
         dnl check the user supplied location
         mc_CHECK_NCURSES_BY_PATH([$ac_ncurses_inc_path],[$ac_ncurses_lib_path])
 
-        LIBS=
-        AC_SEARCH_LIBS([has_colors], [ncurses], [MCLIBS="$MCLIBS $LIBS"], 
+        LIBS="$MCLIBS"
+        AC_SEARCH_LIBS([has_colors], [ncurses], [], 
                        [AC_MSG_ERROR([Cannot find ncurses library])])
-        AC_SEARCH_LIBS([stdscr], [tinfo ncurses], [MCLIBS="$MCLIBS $LIBS"],
+        AC_SEARCH_LIBS([stdscr], [tinfo], [],
                        [AC_MSG_ERROR([Cannot find a library providing stdscr])])
-
+        MCLIBS="$LIBS"
 
         screen_type=ncurses
         screen_msg="NCurses"
         AC_DEFINE(USE_NCURSES, 1, 
                   [Define to use ncurses for screen management])
     else
-        LIBS=
-        AC_SEARCH_LIBS([addwstr], [ncursesw ncurses curses], [MCLIBS="$MCLIBS $LIBS";ncursesw_found=yes],
+        LIBS="$MCLIBS"
+        AC_SEARCH_LIBS([addwstr], [ncursesw ncurses curses], [ncursesw_found=yes],
                        [AC_MSG_WARN([Cannot find ncurses library, that support wide characters])])
-
-        AC_SEARCH_LIBS([stdscr], [tinfow tinfo ncursesw ncurses curses], [MCLIBS="$MCLIBS $LIBS"],
-                       [AC_MSG_ERROR([Cannot find a library providing stdscr])])
+        MCLIBS="$LIBS"
 
         if test x"$ncursesw_found" = "x"; then
-            LIBS=
-            AC_SEARCH_LIBS([has_colors], [ncurses curses], [MCLIBS="$MCLIBS $LIBS"], 
+            LIBS="$MCLIBS"
+            AC_SEARCH_LIBS([has_colors], [ncurses curses], [], 
                            [AC_MSG_ERROR([Cannot find ncurses library])])
-            AC_SEARCH_LIBS([stdscr], [tinfo ncurses curses], [MCLIBS="$MCLIBS $LIBS"],
-                           [AC_MSG_ERROR([Cannot find a library providing stdscr])])
+            MCLIBS="$LIBS"
         fi
+        LIBS="$MCLIBS"
+        AC_SEARCH_LIBS([stdscr], [tinfow tinfo], [MCLIBS="$MCLIBS $LIBS"],
+                       [AC_MSG_ERROR([Cannot find a library providing stdscr])])
+        MCLIBS="$LIBS"
 
         dnl Check the header
         ncurses_h_found=


### PR DESCRIPTION
`AC_SEARCH_LIBS` macro adds required library to `LIBS` variable. Currently `LIBS` could be appended to `MCLIBS` several times leading to duplication of found values.

Also fixed duplication for `stdscr` function detection. 

Additionally fixed potential problematic situation when `addwstr` or `has_colors` detected in one ncurses library (for example `ncurses`), while `stdscr` detected in other ncurses library (for example `curses`). Such combination leads to problems.
