### PR TITLE
Remove duplicated libs from MCLIBS (again)

### DIFF
--- a/m4.include/mc-with-screen-ncurses.m4
+++ b/m4.include/mc-with-screen-ncurses.m4
@@ -122,7 +122,7 @@ AC_DEFUN([mc_WITH_NCURSES], [
             MCLIBS="$LIBS"
         fi
         LIBS="$MCLIBS"
-        AC_SEARCH_LIBS([stdscr], [tinfow tinfo], [MCLIBS="$MCLIBS $LIBS"],
+        AC_SEARCH_LIBS([stdscr], [tinfow tinfo], [],
                        [AC_MSG_ERROR([Cannot find a library providing stdscr])])
         MCLIBS="$LIBS"
 


### PR DESCRIPTION
Follow-up for #187 

Fixed copy-paste error.
This is a correction for 92ae4c6b2027315d32059e8fed2c601a0dff1070.

