### PR TITLE
Fix sed usage in po/Makefile

### DIFF
--- a/po/Rules-pot-defaults
+++ b/po/Rules-pot-defaults
@@ -1,7 +1,7 @@
 
 update-po: Makefile
 	$(MAKE) $(DOMAIN).pot-update && \
-	$(SED) \
+	$${SED-sed} \
 	    -e '/#, fuzzy/d' \
 	    -e 's/Project-Id-Version: PACKAGE VERSION/Project-Id-Version: $(PACKAGE) $(VERSION)/' \
 	    -e 's/^"Plural-Forms: nplurals=INTEGER;/# "Plural-Forms: nplurals=INTEGER;/' \


### PR DESCRIPTION
This is a correction for #184.

`po` directory needs to be treated specially. It does not fully use automake macros and `SED` is not substituted in generated Makefiles.
The only way to add new automatically substituted variable to the Makefile is to add it to Makefile.in.in, however this file is replaced automatically by `autopoint` (with `-f` flag).
All other files, like `Makevars` or `Rules-pot-defaults`, are not processed by configure for variable substitution.
The best way to use `sed` command in this dir is to rely on shell automatic substitution. It does not use `sed` found by `configure`, but the script is portable enough, so the suggest patch does it work without overcomplication.