### PR TITLE
mcedit: fix losing column position when navigating up/down

### DIFF
--- a/src/editor/edit.c
+++ b/src/editor/edit.c
@@ -3015,9 +3015,9 @@ edit_move_to_prev_col (WEdit * edit, off_t p)
         }
         else
         {
-            edit->over_col = 0;
-            edit->prev_col = edit->curs_col;
             edit->curs_col = prev + over;
+            edit->prev_col = edit->curs_col;
+            edit->over_col = 0;
         }
     }
     else


### PR DESCRIPTION
In release 4.8.31, mcedit loses the column position when navigating
up or down in a non-zero column.

Regression from 49bc0ddebfda91ea90d19b286ca1c2198387cf77 v4.8.31
