### PR TITLE
feat(sftpfs): expand %h tokens in ~/.ssh/config HostName directive

### DIFF
--- a/src/vfs/sftpfs/config_parser.c
+++ b/src/vfs/sftpfs/config_parser.c
@@ -131,6 +131,25 @@ sftpfs_correct_file_name (const char *filename)
 }
 
 /* --------------------------------------------------------------------------------------------- */
+/**
+ * Try to expand remote hostname (%h) token.
+ *
+ * @param host hostname string provided by user
+ * @param real_host real hostname string retrieved from the corresponding HostName directive
+ * @return newly allocated string with possibly expanded hostname
+ */
+
+static char *
+sftpsfs_expand_hostname (const char *host, const char *real_host)
+{
+    if (g_str_has_prefix (real_host, "%h")) {
+        return g_strconcat (host, real_host + 2, NULL);
+    } else {
+        return g_strdup (real_host);
+    }
+}
+
+/* --------------------------------------------------------------------------------------------- */
 
 #define POINTER_TO_STRUCTURE_MEMBER(type)  \
     ((type) ((char *) config_entity + (size_t) config_variables[i].offset))
@@ -375,8 +394,7 @@ sftpfs_fill_connection_data_from_config (struct vfs_s_super *super, GError ** mc
 
     if (config_entity->real_host != NULL)
     {
-        g_free (super->path_element->host);
-        super->path_element->host = g_strdup (config_entity->real_host);
+        super->path_element->host = sftpsfs_expand_hostname (super->path_element->host, config_entity->real_host);
     }
 
     if (config_entity->identity_file != NULL)


### PR DESCRIPTION
I'm aware that you do not accept or review pull requests, and I should instead submit a feature request at https://midnight-commander.org

But I haven't received the verification email to a simple @gmail.com mailbox (request to resend does not help) to be able to submit a ticket with the suggested patch.

So perhaps by some miracle, this pr gets your attention. 

The suggested change will allow mc sftp module to properly parse `%h` hostname token, which is widely used in `HostName` directive within `~/.ssh/config`. 

```ini
Host testing*
  HostName %h.eu.example.com

Host staging*
  HostName %h.us.example.net
```

```bash
# this host will be expanded to `testing-1.eu.example.com`
❯ mc sftp://username@testing-1
```

P.S. I'm not a C developer, so the suggestions from other users or devs are welcome.