### PR TITLE
Hide VFS password in progress dialog

### DIFF
--- a/src/filemanager/filegui.c
+++ b/src/filemanager/filegui.c
@@ -1142,12 +1142,8 @@ file_progress_show_source (file_op_context_t * ctx, const vfs_path_t * vpath)
 
     if (vpath != NULL)
     {
-        char *s;
-
-        s = vfs_path_tokens_get (vpath, -1, 1);
         label_set_text (ui->src_file_label, _("Source"));
-        label_set_text (ui->src_file, truncFileString (ui->op_dlg, s));
-        g_free (s);
+        label_set_text (ui->src_file, truncFileStringSecure (ui->op_dlg, vfs_path_as_str (vpath)));
     }
     else
     {


### PR DESCRIPTION
Hello and sorry for submitting the PR here, just like the previous PR here, the Trac email is not arriving, I would much rather submit it there as an issue.

The problem is that it shows VFS (e.g. SFTP) passwords during ops that display VFS source (e.g. copy) in the progress dialog. The proposed change makes the `source` field identical to the one in `target` (i.e. it also includes CWD now), but this way it does not flash the password.

I see that 4.8.32 should be coming very soon, so I was hoping to get this squeezed in time for the release.

Thank you!
