### PR TITLE
Make the iso9660 extfs helper read-only

### DIFF
--- a/src/vfs/extfs/helpers/iso9660.in
+++ b/src/vfs/extfs/helpers/iso9660.in
@@ -114,34 +114,6 @@ xorriso_copyout() {
     $XORRISO -dev stdio:"$1" -osirrox on -extract "$2" "$3" >/dev/null 2>&1
 }
 
-xorriso_copyin() {
-    if test -z "$XORRISO"; then
-        return 1
-    fi
-    $XORRISO -dev stdio:"$1" -cpr "$3" "$2" >/dev/null 2>&1
-}
-
-xorriso_mkdir() {
-    if test -z "$XORRISO"; then
-        return 1
-    fi
-    $XORRISO -dev stdio:"$1" -mkdir "$2" >/dev/null 2>&1
-}
-
-xorriso_rmdir() {
-    if test -z "$XORRISO"; then
-        return 1
-    fi
-    $XORRISO -dev stdio:"$1" -rmdir "$2" >/dev/null 2>&1
-}
-
-xorriso_rm() {
-    if test -z "$XORRISO"; then
-        return 1
-    fi
-    $XORRISO -dev stdio:"$1" -rm "$2" >/dev/null 2>&1
-}
-
 # tested to comply with isoinfo 2.0's output
 test_iso () {
     ISOINFO=$(which isoinfo 2>/dev/null)
@@ -263,30 +235,6 @@ case "$cmd" in
     xorriso_list "$@" || {
         test_iso "$@" || exit 1
         mcisofs_list "$@" || exit 1
-    }
-    exit 0
-    ;;
-  rm)
-    xorriso_rm "$@" || {
-        exit 1
-    }
-    exit 0
-    ;;
-  rmdir)
-    xorriso_rmdir "$@" || {
-        exit 1
-    }
-    exit 0
-    ;;
-  mkdir)
-    xorriso_mkdir "$@" || {
-        exit 1
-    }
-    exit 0
-    ;;
-  copyin)
-    xorriso_copyin "$@" || {
-        exit 1
     }
     exit 0
     ;;


### PR DESCRIPTION
## mc should NOT edit iso images

### Fundamental problem

Quoting man xorriso:

> The method of growing adds new data to the existing data on the medium. These data comprise of new file content and they override the existing ISO 9660 + Rock Ridge directory tree. It is possible to hide files from previous sessions but they still exist on the medium and with many types of optical media it is quite easy to recover them by mounting older sessions. Growing is achieved by command -dev.
>
> Modifying takes place if input drive and output drive are not the same and if command -grow_blindly is set to its default "off". This is achieved by commands -indev and -outdev.

*Modified* images comprise a single session. *Grown* ones bear a session per a set of commited changes.

A session consists of a 64K superblock, directory data (if any) for the whole image and new (if any) data blocks. There is also 300K padding by default, it can be disabled with `-padding 0`. In the end it is aligned to 64K boundary.

In the best case (the image is empty and we only change something in the superblock), a session adds 64K to the image. For example, updating the volume id with `-volid` for an empty image is +64K. When there is some directory data,
it is +128K at least. The session overhead could be pretty big: it is over 11M for debian-12.5.0-amd64-DVD-1.iso.

The good point of *growing* is speed: it only writes the delta (plus the session overhead). It is suitable for adding data to real media. But there is no point in using it with images since *modified* images are smaller (no extra session overhead, no blocks of removed files).

**In both cases, there is a showstopper to use it with mc**:

- removed files should actually be removed. When a user removes a big file from some iso image, it is expected for the image to become significantly smaller, not slightly larger. Hence, *growing* is not an option
- simple changes should not result in lots of writes. When a user creates a dir in some 4G image it is NOT expected to trigger 4G of writes. Hence, *modifying* is not an option


### Appendix: Side effects of simple commands mc currently uses

Any changes should preserve other attributes e.g. *El Torito data*, *Rock Ridge* and *Joliet* presence. For example, such innocent looking command (in this case it does not matter if changes are made in-place or not):

    xorriso -dev 1.iso -mkdir /test

wipes El Torito data, enables Rock Ridge and disables Joliet. To make it not alter those, it should be at least like this:

    features=$(xorriso -dev 1.iso -toc 2>/dev/null | grep '^ISO offers')

    extra=(-boot_image any replay)
    [[ $features == *Rock_Ridge* ]] || extra+=(-rockridge off)
    [[ $features == *Joliet* ]] && extra+=(-joliet on)

    xorriso -dev 1.iso "${extra[@]}" -mkdir /test
