### PR TITLE
Ticket #4605: Do not override ENV variable for ash/dash subshell

### DIFF
--- a/src/subshell/common.c
+++ b/src/subshell/common.c
@@ -360,8 +360,9 @@ init_subshell_child (const char *pty_name)
             init_file = g_strdup (".profile");
         }
 
-        /* Put init file to ENV variable used by ash */
-        g_setenv ("ENV", init_file, TRUE);
+        /* Put init file to ENV variable used by ash but only if it
+           is not already set. */
+        g_setenv ("ENV", init_file, FALSE);
 
         break;
 


### PR DESCRIPTION
Do not override ENV variable (by ".profile") for ash/dash subshell if it is already set.   ENV variable is used to specify the "rc" file for POSIX shells, it's more or less equivalent to .bashrc for bash that mc already (and correctly) fallbacks to for bash.   I believe fallback to ENV is more consistent than to .profile.

> Thank you for thinking about contributing to Midnight Commander, but we **ARE NOT** using pull requests to manage incoming patches!
> 
> Instead, please check out our Trac instance to see if the issue has already been reported, or submit a new ticket:
> 
> https://midnight-commander.org/wiki/NewTicket
> 
> If you chose to submit the pull request instead, keep in mind that we are not checking on them regularly, so it might take ages before we even get to it, if at all.
> 
> Unfortunately, GitHub does not allow us to disable the pull requests feature for this repository, so we have to warn you this way...
> 